### PR TITLE
compile error for `else if`

### DIFF
--- a/qtc/parser.go
+++ b/qtc/parser.go
@@ -402,8 +402,12 @@ func (p *parser) parseIf() error {
 				if elseUsed {
 					return fmt.Errorf("duplicate else branch found for %q at %s", ifStr, s.Context())
 				}
-				if err = skipTagContents(s); err != nil {
+				tok, err := expectToken(s, tagContents)
+				if err != nil {
 					return err
+				}
+				if len(tok.Value) > 0 {
+					return fmt.Errorf("unexpected content after else: %q at %s", tok.Value, s.Context())
 				}
 				p.prefix = p.prefix[1:]
 				p.Printf("} else {")

--- a/qtc/parser_test.go
+++ b/qtc/parser_test.go
@@ -293,6 +293,9 @@ func TestParseFailure(t *testing.T) {
 	// empty if condition
 	testParseFailure(t, "{% func a() %}{% if    %}aaaa{% endif %}{% endfunc %}")
 
+	// else with content
+	testParseFailure(t, "{% func a() %}{% if 3 == 4%}aaaa{% else if 3 ==  5 %}bug{% endif %}{% endfunc %}")
+
 	// missing endif
 	testParseFailure(t, "{%func a() %}{%if foo %}aaa{% endfunc %}")
 


### PR DESCRIPTION
This code will produce a `duplicate else branch found`:

```
{% if 3 == 4 %}
  3 is not 4
{% else if 4 == 5 %}
  bug
{% else %}
  compile error
{% endif %}
```

But this code will compile and output `bug`:

```
{% if 3 == 4 %}
  3 is not 4
{% else if 4 == 5 %}
  bug
{% endif %}
```

I got confused by this today, as syntax is so close to go.
This PR will produce a compile error in this case.
