### PR TITLE
Support for variadic functions

### DIFF
--- a/qtc/functype.go
+++ b/qtc/functype.go
@@ -88,7 +88,11 @@ func parseFuncDef(b []byte) (*funcType, error) {
 			if n == nil {
 				return nil, fmt.Errorf("func cannot contain untyped arguments")
 			}
-			tmp = append(tmp, n.Name)
+			if _, isVariadic := f.Type.(*ast.Ellipsis); isVariadic {
+				tmp = append(tmp, n.Name+"...")
+			} else {
+				tmp = append(tmp, n.Name)
+			}
 		}
 	}
 	argNames := strings.Join(tmp, ", ")

--- a/qtc/functype_test.go
+++ b/qtc/functype_test.go
@@ -104,6 +104,11 @@ func TestParseFuncDefSuccess(t *testing.T) {
 	testParseFuncDefSuccess(t, "(t TPL) Head(h1, h2 func(x, y int), h3 map[int]struct{})", "(t TPL) Head(h1, h2 func(x, y int), h3 map[int]struct{}) string",
 		"(t TPL) StreamHead(qw422016 *qt422016.Writer, h1, h2 func(x, y int), h3 map[int]struct{})", "t.StreamHead(qw422016, h1, h2, h3)",
 		"(t TPL) WriteHead(qq422016 qtio422016.Writer, h1, h2 func(x, y int), h3 map[int]struct{})", "t.WriteHead(qq422016, h1, h2, h3)")
+
+	// method with variadic arguments
+	testParseFuncDefSuccess(t, "(t TPL) Head(name string, num int, otherNames ...string)", "(t TPL) Head(name string, num int, otherNames ...string) string",
+		"(t TPL) StreamHead(qw422016 *qt422016.Writer, name string, num int, otherNames ...string)", "t.StreamHead(qw422016, name, num, otherNames...)",
+		"(t TPL) WriteHead(qq422016 qtio422016.Writer, name string, num int, otherNames ...string)", "t.WriteHead(qq422016, name, num, otherNames...)")
 }
 
 func TestParseFuncDefFailure(t *testing.T) {


### PR DESCRIPTION
Wanted to allow for extra "optional" class names, something like:

```
{% func tableCell(name string, num int, extraClassNames ...string) %}
```

Does this look acceptable?  Happy to revise if necessary.