### PR TITLE
fix deprecated note for ByteBuffer type

### DIFF
--- a/bytebuffer.go
+++ b/bytebuffer.go
@@ -9,7 +9,7 @@ import (
 // Recycle byte buffers via AcquireByteBuffer and ReleaseByteBuffer
 // in order to reduce memory allocations.
 //
-// ByteBuffer is deprecated. Use github.com/valyala/bytebufferpool instead.
+// Deprecated: use github.com/valyala/bytebufferpool instead.
 type ByteBuffer bytebufferpool.ByteBuffer
 
 // Write implements io.Writer.


### PR DESCRIPTION
The proper format is a comment that starts with
"Deprecated:" as described in godoc docs.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>