### PR TITLE
Feature/#37 delimiters configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 tags
+**/*.qtpl.go
+*.qtpl.go

--- a/qtc/main.go
+++ b/qtc/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"flag"
+	"fmt"
 	"go/format"
 	"io/ioutil"
 	"log"
@@ -27,27 +29,58 @@ var logger = log.New(os.Stderr, "qtc: ", log.LstdFlags)
 
 var filesCompiled int
 
+type tt struct {
+	ID    int
+	Value string
+}
+
+func testIt() {
+	str := "header {%stripspace %} toto et tata {%endstripspace %} footer"
+	r := bytes.NewBufferString(str)
+	s := NewScanWithTagConf(r, "memory", "{%", "%}")
+	var tokens []tt
+	i := 0
+	for s.Next() {
+		tok := s.Token()
+		id := tok.ID
+		val := string(tok.Value)
+		fmt.Printf("%d - %s\n", id, val)
+		tokens = append(tokens, tt{
+			ID:    s.Token().ID,
+			Value: string(s.Token().Value),
+		})
+		fmt.Printf("token[%d] : %d - %s\n", i, s.Token().ID, string(s.Token().Value))
+		i++
+	}
+	count := len(tokens)
+
+	fmt.Printf("found %d tokens when scanning %q.  \n", count, str)
+}
+
 func main() {
-	flag.Parse()
 
-	if len(*file) > 0 {
-		compileSingleFile(*file)
-		return
-	}
+	testIt()
 
-	if len(*ext) == 0 {
-		logger.Fatalf("ext cannot be empty")
-	}
-	if len(*dir) == 0 {
-		*dir = "."
-	}
-	if (*ext)[0] != '.' {
-		*ext = "." + *ext
-	}
+	// flag.Parse()
 
-	logger.Printf("Compiling *%s template files in directory %q", *ext, *dir)
-	compileDir(*dir)
-	logger.Printf("Total files compiled: %d", filesCompiled)
+	// if len(*file) > 0 {
+	// 	compileSingleFile(*file)
+	// 	return
+	// }
+
+	// if len(*ext) == 0 {
+	// 	logger.Fatalf("ext cannot be empty")
+	// }
+	// if len(*dir) == 0 {
+	// 	*dir = "."
+	// }
+	// if (*ext)[0] != '.' {
+	// 	*ext = "." + *ext
+	// }
+
+	// logger.Printf("Compiling *%s template files in directory %q", *ext, *dir)
+	// compileDir(*dir)
+	// logger.Printf("Total files compiled: %d", filesCompiled)
 }
 
 func compileSingleFile(filename string) {

--- a/qtc/main.go
+++ b/qtc/main.go
@@ -29,23 +29,51 @@ var logger = log.New(os.Stderr, "qtc: ", log.LstdFlags)
 
 var filesCompiled int
 
-type tt struct {
+type myToken struct {
 	ID    int
 	Value string
 }
 
-func testIt() {
+func testItBrace() {
 	str := "header {%stripspace %} toto et tata {%endstripspace %} footer"
 	r := bytes.NewBufferString(str)
-	s := NewScanWithTagConf(r, "memory", "{%", "%}")
-	var tokens []tt
+	s := newScanner(r, "memory")
+	var tokens []myToken
 	i := 0
 	for s.Next() {
 		tok := s.Token()
 		id := tok.ID
 		val := string(tok.Value)
 		fmt.Printf("%d - %s\n", id, val)
-		tokens = append(tokens, tt{
+		tokens = append(tokens, myToken{
+			ID:    s.Token().ID,
+			Value: string(s.Token().Value),
+		})
+		fmt.Printf("token[%d] : %d - %s\n", i, s.Token().ID, string(s.Token().Value))
+		i++
+	}
+	count := len(tokens)
+
+	fmt.Printf("found %d tokens when scanning %q.  \n", count, str)
+}
+
+func testItBracket() {
+	str := `header [%stripspace %] 
+	toto 
+	{% moustache %}   
+	et   
+	tata    
+	[%endstripspace %] footer`
+	r := bytes.NewBufferString(str)
+	s := newScannerWithTagConf(r, "memory", "[%", "%]")
+	var tokens []myToken
+	i := 0
+	for s.Next() {
+		tok := s.Token()
+		id := tok.ID
+		val := string(tok.Value)
+		fmt.Printf("%d - %s\n", id, val)
+		tokens = append(tokens, myToken{
 			ID:    s.Token().ID,
 			Value: string(s.Token().Value),
 		})
@@ -59,7 +87,8 @@ func testIt() {
 
 func main() {
 
-	testIt()
+	//testItBrace()
+	testItBracket()
 
 	// flag.Parse()
 

--- a/qtc/main.go
+++ b/qtc/main.go
@@ -21,16 +21,37 @@ var (
 		"Flags -dir and -ext are ignored if file is set.\n"+
 		"The compiled file will be placed near the original file with .go extension added.")
 	ext      = flag.String("ext", "qtpl", "Only files with this extension are compiled")
+	s        = flag.String("s", "", "starting")
 	startTag = flag.String("sTag", "{%", "tag starting delimiter (2 chars)")
-	endTag   = flag.String("eTag", "{%", "tag ending delimiter (2 chars)")
+	endTag   = flag.String("eTag", "%}", "tag ending delimiter (2 chars)")
 )
 
 var logger = log.New(os.Stderr, "qtc: ", log.LstdFlags)
 
 var filesCompiled int
 
+func checkDelimiters() {
+	start := *startTag
+	end := *endTag
+
+	if len(start) != 2 {
+		logger.Fatalf("tag starting delimiter '%s' must be 2 chars length", start)
+	}
+	if len(end) != 2 {
+		logger.Fatalf("tag ending delimiter '%s' must be 2 chars length", end)
+	}
+
+	if start[1] != end[0] {
+		logger.Fatalf("starting delimiter last char ('%s') and ending delimiter first char ('%s') must be the same", string(start[1]), string(end[0]))
+	}
+
+}
+
 func main() {
+
 	flag.Parse()
+
+	checkDelimiters()
 
 	if len(*file) > 0 {
 		compileSingleFile(*file)

--- a/qtc/parser.go
+++ b/qtc/parser.go
@@ -13,7 +13,7 @@ import (
 )
 
 type parser struct {
-	s               *Scanner
+	s               *scanner
 	w               io.Writer
 	packageName     string
 	prefix          string
@@ -805,7 +805,7 @@ func (p *parser) Printf(format string, args ...interface{}) {
 	fmt.Fprintf(w, "\n")
 }
 
-func skipTagContents(s *Scanner) error {
+func skipTagContents(s *scanner) error {
 	tagName := string(s.Token().Value)
 	t, err := expectTagContents(s)
 	if err != nil {
@@ -817,11 +817,11 @@ func skipTagContents(s *Scanner) error {
 	return err
 }
 
-func expectTagContents(s *Scanner) (*token, error) {
+func expectTagContents(s *scanner) (*token, error) {
 	return expectToken(s, tagContents)
 }
 
-func expectToken(s *Scanner, id int) (*token, error) {
+func expectToken(s *scanner, id int) (*token, error) {
 	if !s.Next() {
 		return nil, fmt.Errorf("cannot find token %s: %v", tokenIDToStr(id), s.LastError())
 	}

--- a/qtc/parser.go
+++ b/qtc/parser.go
@@ -25,11 +25,25 @@ type parser struct {
 	packageNameEmitted bool
 }
 
-func parse(w io.Writer, r io.Reader, filePath, packageName string) error {
-	p := &parser{
-		s:           newScanner(r, filePath),
-		w:           w,
-		packageName: packageName,
+type config struct {
+	TagStartingDelimiter string
+	TagEndingDelimiter   string
+}
+
+func parse(w io.Writer, r io.Reader, filePath, packageName string, parserConfig *config) error {
+	var p *parser
+	if parserConfig == nil {
+		p = &parser{
+			s:           newScanner(r, filePath),
+			w:           w,
+			packageName: packageName,
+		}
+	} else {
+		p = &parser{
+			s:           newScannerWithTagConf(r, filePath, parserConfig.TagStartingDelimiter, parserConfig.TagEndingDelimiter),
+			w:           w,
+			packageName: packageName,
+		}
 	}
 	return p.parseTemplate()
 }

--- a/qtc/parser.go
+++ b/qtc/parser.go
@@ -13,7 +13,7 @@ import (
 )
 
 type parser struct {
-	s               *scanner
+	s               *Scanner
 	w               io.Writer
 	packageName     string
 	prefix          string
@@ -805,7 +805,7 @@ func (p *parser) Printf(format string, args ...interface{}) {
 	fmt.Fprintf(w, "\n")
 }
 
-func skipTagContents(s *scanner) error {
+func skipTagContents(s *Scanner) error {
 	tagName := string(s.Token().Value)
 	t, err := expectTagContents(s)
 	if err != nil {
@@ -817,11 +817,11 @@ func skipTagContents(s *scanner) error {
 	return err
 }
 
-func expectTagContents(s *scanner) (*token, error) {
+func expectTagContents(s *Scanner) (*token, error) {
 	return expectToken(s, tagContents)
 }
 
-func expectToken(s *scanner, id int) (*token, error) {
+func expectToken(s *Scanner, id int) (*token, error) {
 	if !s.Next() {
 		return nil, fmt.Errorf("cannot find token %s: %v", tokenIDToStr(id), s.LastError())
 	}

--- a/qtc/parser_test.go
+++ b/qtc/parser_test.go
@@ -549,7 +549,7 @@ else
 func testParseFailure(t *testing.T, str string) {
 	r := bytes.NewBufferString(str)
 	w := &bytes.Buffer{}
-	if err := parse(w, r, "./foobar.tpl", "memory"); err == nil {
+	if err := parse(w, r, "./foobar.tpl", "memory", nil); err == nil {
 		t.Fatalf("expecting error when parsing %q", str)
 	}
 }
@@ -557,7 +557,7 @@ func testParseFailure(t *testing.T, str string) {
 func testParseSuccess(t *testing.T, str string) {
 	r := bytes.NewBufferString(str)
 	w := &bytes.Buffer{}
-	if err := parse(w, r, "./foobar.tpl", "memory"); err != nil {
+	if err := parse(w, r, "./foobar.tpl", "memory", nil); err != nil {
 		t.Fatalf("unexpected error when parsing %q: %s", str, err)
 	}
 }
@@ -576,7 +576,7 @@ func TestParseFile(t *testing.T) {
 	}
 
 	w := quicktemplate.AcquireByteBuffer()
-	if err := parse(w, f, filename, packageName); err != nil {
+	if err := parse(w, f, filename, packageName, nil); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 	code, err := format.Source(w.B)

--- a/qtc/scanner.go
+++ b/qtc/scanner.go
@@ -284,8 +284,8 @@ func (s *scanner) readTagName() bool {
 	s.skipSpace()
 	s.t.init(tagName, s.line, s.pos())
 	for {
-		if s.isSpace() || s.c == '%' {
-			if s.c == '%' {
+		if s.isSpace() || s.c == s.closingTag[0] {
+			if s.c == s.closingTag[0] {
 				s.unreadByte('~')
 			}
 			s.nextTokenID = tagContents
@@ -308,7 +308,7 @@ func (s *scanner) readTagContents() bool {
 	s.skipSpace()
 	s.t.init(tagContents, s.line, s.pos())
 	for {
-		if s.c != s.closingTag[0] {
+		if s.c != s.openingTag[0] {
 			s.appendByte()
 			if !s.nextByte() {
 				return false
@@ -319,7 +319,7 @@ func (s *scanner) readTagContents() bool {
 			s.appendByte()
 			return false
 		}
-		if s.c == s.closingTag[1] {
+		if s.c == s.openingTag[1] {
 			s.nextTokenID = text
 			s.t.Value = stripTrailingSpace(s.t.Value)
 			return true

--- a/qtc/scanner.go
+++ b/qtc/scanner.go
@@ -308,7 +308,7 @@ func (s *scanner) readTagContents() bool {
 	s.skipSpace()
 	s.t.init(tagContents, s.line, s.pos())
 	for {
-		if s.c != s.openingTag[0] {
+		if s.c != s.closingTag[0] {
 			s.appendByte()
 			if !s.nextByte() {
 				return false
@@ -319,12 +319,12 @@ func (s *scanner) readTagContents() bool {
 			s.appendByte()
 			return false
 		}
-		if s.c == s.openingTag[1] {
+		if s.c == s.closingTag[1] {
 			s.nextTokenID = text
 			s.t.Value = stripTrailingSpace(s.t.Value)
 			return true
 		}
-		s.unreadByte('%')
+		s.unreadByte(s.closingTag[0])
 		s.appendByte()
 		if !s.nextByte() {
 			return false

--- a/qtc/scanner.go
+++ b/qtc/scanner.go
@@ -88,10 +88,7 @@ func newScannerWithTagConf(r io.Reader, filePath string, openTag string, closeTa
 }
 
 func newScanner(r io.Reader, filePath string) *Scanner {
-	return &Scanner{
-		r:        bufio.NewReader(r),
-		filePath: filePath,
-	}
+	return newScannerWithTagConf(r, filePath, "{%", "%}")
 }
 
 func (s *Scanner) Rewind() {

--- a/qtc/scanner.go
+++ b/qtc/scanner.go
@@ -264,7 +264,7 @@ func (s *scanner) readText() bool {
 			ok = true
 			break
 		}
-		if s.c == '%' {
+		if s.c == s.openingTag[1] {
 			s.nextTokenID = tagName
 			ok = true
 			break

--- a/qtc/scanner_test.go
+++ b/qtc/scanner_test.go
@@ -220,6 +220,63 @@ func testScannerSuccess(t *testing.T, str string, expectedTokens []tt) {
 	}
 }
 
+func TestConfigurationScannerSuccess(t *testing.T) {
+	testConfigurationScannerSuccess(t, "", "[%", "%]", nil)
+	testConfigurationScannerSuccess(t, "a%]{foo}bar", "[%", "%]", []tt{
+		{ID: text, Value: "a%]{foo}bar"},
+	})
+	testConfigurationScannerSuccess(t, "[% foo bar baz(a, b, 123) %]", "[%", "%]", []tt{
+		{ID: tagName, Value: "foo"},
+		{ID: tagContents, Value: "bar baz(a, b, 123)"},
+	})
+	testConfigurationScannerSuccess(t, "foo[%bar%]baz", "[%", "%]", []tt{
+		{ID: text, Value: "foo"},
+		{ID: tagName, Value: "bar"},
+		{ID: tagContents, Value: ""},
+		{ID: text, Value: "baz"},
+	})
+	testConfigurationScannerSuccess(t, "{{[%\n\r\tfoo bar\n\rbaz%%\n   \r %]}", "[%", "%]", []tt{
+		{ID: text, Value: "{{"},
+		{ID: tagName, Value: "foo"},
+		{ID: tagContents, Value: "bar\n\rbaz%%"},
+		{ID: text, Value: "}"},
+	})
+	testConfigurationScannerSuccess(t, "[%%]", "[%", "%]", []tt{
+		{ID: tagName, Value: ""},
+		{ID: tagContents, Value: ""},
+	})
+	testConfigurationScannerSuccess(t, "[%%aaa bb%]", "[%", "%]", []tt{
+		{ID: tagName, Value: ""},
+		{ID: tagContents, Value: "%aaa bb"},
+	})
+	testConfigurationScannerSuccess(t, "foo[% bar %][% baz aa (123)%]321", "[%", "%]", []tt{
+		{ID: text, Value: "foo"},
+		{ID: tagName, Value: "bar"},
+		{ID: tagContents, Value: ""},
+		{ID: tagName, Value: "baz"},
+		{ID: tagContents, Value: "aa (123)"},
+		{ID: text, Value: "321"},
+	})
+}
+
+func testConfigurationScannerSuccess(t *testing.T, str string, startTag string, endTag string, expectedTokens []tt) {
+	r := bytes.NewBufferString(str)
+	s := newScannerWithTagConf(r, "memory", startTag, endTag)
+	var tokens []tt
+	for s.Next() {
+		tokens = append(tokens, tt{
+			ID:    s.Token().ID,
+			Value: string(s.Token().Value),
+		})
+	}
+	if err := s.LastError(); err != nil {
+		t.Fatalf("unexpected error: %s. str=%q", err, str)
+	}
+	if !reflect.DeepEqual(tokens, expectedTokens) {
+		t.Fatalf("unexpected tokens %v. Expecting %v. str=%q", tokens, expectedTokens, str)
+	}
+}
+
 type tt struct {
 	ID    int
 	Value string

--- a/qtc/scanner_test.go
+++ b/qtc/scanner_test.go
@@ -220,70 +220,70 @@ func testScannerSuccess(t *testing.T, str string, expectedTokens []tt) {
 	}
 }
 
-func TestConfigurationScannerSuccess(t *testing.T) {
-	testConfigurationScannerSuccess(t, "", "[%", "%]", nil)
-	testConfigurationScannerSuccess(t, "a%]{foo}bar", "[%", "%]", []tt{
-		{ID: text, Value: "a%]{foo}bar"},
-	})
-	testConfigurationScannerSuccess(t, "[% foo bar baz(a, b, 123) %]", "[%", "%]", []tt{
-		{ID: tagName, Value: "foo"},
-		{ID: tagContents, Value: "bar baz(a, b, 123)"},
-	})
-	testConfigurationScannerSuccess(t, "foo[%bar%]baz", "[%", "%]", []tt{
-		{ID: text, Value: "foo"},
-		{ID: tagName, Value: "bar"},
-		{ID: tagContents, Value: ""},
-		{ID: text, Value: "baz"},
-	})
-	testConfigurationScannerSuccess(t, "{{[%\n\r\tfoo bar\n\rbaz%%\n   \r %]}", "[%", "%]", []tt{
-		{ID: text, Value: "{{"},
-		{ID: tagName, Value: "foo"},
-		{ID: tagContents, Value: "bar\n\rbaz%%"},
-		{ID: text, Value: "}"},
-	})
-	testConfigurationScannerSuccess(t, "[%%]", "[%", "%]", []tt{
-		{ID: tagName, Value: ""},
-		{ID: tagContents, Value: ""},
-	})
-	testConfigurationScannerSuccess(t, "[%%aaa bb%]", "[%", "%]", []tt{
-		{ID: tagName, Value: ""},
-		{ID: tagContents, Value: "%aaa bb"},
-	})
-	testConfigurationScannerSuccess(t, "foo[% bar %][% baz aa (123)%]321", "[%", "%]", []tt{
-		{ID: text, Value: "foo"},
-		{ID: tagName, Value: "bar"},
-		{ID: tagContents, Value: ""},
-		{ID: tagName, Value: "baz"},
-		{ID: tagContents, Value: "aa (123)"},
-		{ID: text, Value: "321"},
-	})
-	testConfigurationScannerSuccess(t, "  aa\n\t [%stripspace%] \t\n  f\too \n   b  ar \n\r\t [%  bar baz  asd %]\n\nbaz \n\t \taaa  \n[%endstripspace%] bb  ", "[%", "%]", []tt{
-		{ID: text, Value: "  aa\n\t "},
-		{ID: text, Value: "f\toob  ar"},
-		{ID: tagName, Value: "bar"},
-		{ID: tagContents, Value: "baz  asd"},
-		{ID: text, Value: "bazaaa"},
-		{ID: text, Value: " bb  "},
-	})
-}
+// func TestConfigurationScannerSuccess(t *testing.T) {
+// 	testConfigurationScannerSuccess(t, "", "[%", "%]", nil)
+// 	testConfigurationScannerSuccess(t, "a%]{foo}bar", "[%", "%]", []tt{
+// 		{ID: text, Value: "a%]{foo}bar"},
+// 	})
+// 	testConfigurationScannerSuccess(t, "[% foo bar baz(a, b, 123) %]", "[%", "%]", []tt{
+// 		{ID: tagName, Value: "foo"},
+// 		{ID: tagContents, Value: "bar baz(a, b, 123)"},
+// 	})
+// 	testConfigurationScannerSuccess(t, "foo[%bar%]baz", "[%", "%]", []tt{
+// 		{ID: text, Value: "foo"},
+// 		{ID: tagName, Value: "bar"},
+// 		{ID: tagContents, Value: ""},
+// 		{ID: text, Value: "baz"},
+// 	})
+// 	testConfigurationScannerSuccess(t, "{{[%\n\r\tfoo bar\n\rbaz%%\n   \r %]}", "[%", "%]", []tt{
+// 		{ID: text, Value: "{{"},
+// 		{ID: tagName, Value: "foo"},
+// 		{ID: tagContents, Value: "bar\n\rbaz%%"},
+// 		{ID: text, Value: "}"},
+// 	})
+// 	testConfigurationScannerSuccess(t, "[%%]", "[%", "%]", []tt{
+// 		{ID: tagName, Value: ""},
+// 		{ID: tagContents, Value: ""},
+// 	})
+// 	testConfigurationScannerSuccess(t, "[%%aaa bb%]", "[%", "%]", []tt{
+// 		{ID: tagName, Value: ""},
+// 		{ID: tagContents, Value: "%aaa bb"},
+// 	})
+// 	testConfigurationScannerSuccess(t, "foo[% bar %][% baz aa (123)%]321", "[%", "%]", []tt{
+// 		{ID: text, Value: "foo"},
+// 		{ID: tagName, Value: "bar"},
+// 		{ID: tagContents, Value: ""},
+// 		{ID: tagName, Value: "baz"},
+// 		{ID: tagContents, Value: "aa (123)"},
+// 		{ID: text, Value: "321"},
+// 	})
+// 	testConfigurationScannerSuccess(t, "  aa\n\t [%stripspace%] \t\n  f\too \n   b  ar \n\r\t [%  bar baz  asd %]\n\nbaz \n\t \taaa  \n[%endstripspace%] bb  ", "[%", "%]", []tt{
+// 		{ID: text, Value: "  aa\n\t "},
+// 		{ID: text, Value: "f\toob  ar"},
+// 		{ID: tagName, Value: "bar"},
+// 		{ID: tagContents, Value: "baz  asd"},
+// 		{ID: text, Value: "bazaaa"},
+// 		{ID: text, Value: " bb  "},
+// 	})
+// }
 
-func testConfigurationScannerSuccess(t *testing.T, str string, startTag string, endTag string, expectedTokens []tt) {
-	r := bytes.NewBufferString(str)
-	s := newScannerWithTagConf(r, "memory", startTag, endTag)
-	var tokens []tt
-	for s.Next() {
-		tokens = append(tokens, tt{
-			ID:    s.Token().ID,
-			Value: string(s.Token().Value),
-		})
-	}
-	if err := s.LastError(); err != nil {
-		t.Fatalf("unexpected error: %s. str=%q", err, str)
-	}
-	if !reflect.DeepEqual(tokens, expectedTokens) {
-		t.Fatalf("unexpected tokens %v. Expecting %v. str=%q", tokens, expectedTokens, str)
-	}
-}
+// func testConfigurationScannerSuccess(t *testing.T, str string, startTag string, endTag string, expectedTokens []tt) {
+// 	r := bytes.NewBufferString(str)
+// 	s := newScannerWithTagConf(r, "memory", startTag, endTag)
+// 	var tokens []tt
+// 	for s.Next() {
+// 		tokens = append(tokens, tt{
+// 			ID:    s.Token().ID,
+// 			Value: string(s.Token().Value),
+// 		})
+// 	}
+// 	if err := s.LastError(); err != nil {
+// 		t.Fatalf("unexpected error: %s. str=%q", err, str)
+// 	}
+// 	if !reflect.DeepEqual(tokens, expectedTokens) {
+// 		t.Fatalf("unexpected tokens %v. Expecting %v. str=%q", tokens, expectedTokens, str)
+// 	}
+// }
 
 type tt struct {
 	ID    int

--- a/qtc/scanner_test.go
+++ b/qtc/scanner_test.go
@@ -257,6 +257,14 @@ func TestConfigurationScannerSuccess(t *testing.T) {
 		{ID: tagContents, Value: "aa (123)"},
 		{ID: text, Value: "321"},
 	})
+	testConfigurationScannerSuccess(t, "  aa\n\t [%stripspace%] \t\n  f\too \n   b  ar \n\r\t [%  bar baz  asd %]\n\nbaz \n\t \taaa  \n[%endstripspace%] bb  ", "[%", "%]", []tt{
+		{ID: text, Value: "  aa\n\t "},
+		{ID: text, Value: "f\toob  ar"},
+		{ID: tagName, Value: "bar"},
+		{ID: tagContents, Value: "baz  asd"},
+		{ID: text, Value: "bazaaa"},
+		{ID: text, Value: " bb  "},
+	})
 }
 
 func testConfigurationScannerSuccess(t *testing.T, str string, startTag string, endTag string, expectedTokens []tt) {

--- a/qtc/scanner_with_conf_test.go
+++ b/qtc/scanner_with_conf_test.go
@@ -1,0 +1,349 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+/*TestScannerConfigurationTagNameWithDotAndEqual ..."
+ */
+func TestScannerConfigurationTagNameWithDotAndEqual(t *testing.T) {
+	testScannerConfigurationSuccess(t, "[{foo.bar.34 baz aaa}] awer[{ aa= }]",
+		[]confToken{
+			{ID: tagName, Value: "foo.bar.34"},
+			{ID: tagContents, Value: "baz aaa"},
+			{ID: text, Value: " awer"},
+			{ID: tagName, Value: "aa="},
+			{ID: tagContents, Value: ""},
+		})
+}
+
+/*TestScannerConfigurationStripspaceSuccess ...
+ */
+func TestScannerConfigurationStripspaceSuccess(t *testing.T) {
+	testScannerConfigurationSuccess(t, "  aa\n\t [{stripspace}] \t\n  f\too \n   b  ar \n\r\t [{  bar baz  asd }]\n\nbaz \n\t \taaa  \n[{endstripspace}] bb  ", []confToken{
+		{ID: text, Value: "  aa\n\t "},
+		{ID: text, Value: "f\toob  ar"},
+		{ID: tagName, Value: "bar"},
+		{ID: tagContents, Value: "baz  asd"},
+		{ID: text, Value: "bazaaa"},
+		{ID: text, Value: " bb  "},
+	})
+	testScannerConfigurationSuccess(t, "[{stripspace  }][{ stripspace fobar }] [{space}]  a\taa\n\r\t bb  b  [{endstripspace  }]  [{endstripspace  baz}]", []confToken{
+		{ID: text, Value: " "},
+		{ID: text, Value: "a\taabb  b"},
+	})
+
+	// sripspace wins over collapsespace
+	testScannerConfigurationSuccess(t, "[{stripspace}] [{collapsespace}]foo\n\t bar[{endcollapsespace}] \r\n\t [{endstripspace}]", []confToken{
+		{ID: text, Value: "foobar"},
+	})
+}
+
+/*TestScannerConfigurationStripspaceFailure ...
+ */
+func TestScannerConfigurationStripspaceFailure(t *testing.T) {
+	// incomplete stripspace tag
+	testScannerConfigurationFailure(t, "[{stripspace   ")
+
+	// incomplete endstripspace tag
+	testScannerConfigurationFailure(t, "[{stripspace}]aaa[{endstripspace")
+
+	// missing endstripspace
+	testScannerConfigurationFailure(t, "[{stripspace}] foobar")
+
+	// missing stripspace
+	testScannerConfigurationFailure(t, "aaa[{endstripspace}]")
+
+	// missing the second endstripspace
+	testScannerConfigurationFailure(t, "[{stripspace}][{stripspace}]aaaa[{endstripspace}]")
+}
+
+/*TestScannerConfigurationCollapsespaceSuccess ...
+ */
+func TestScannerConfigurationCollapsespaceSuccess(t *testing.T) {
+	testScannerConfigurationSuccess(t, "  aa\n\t [{collapsespace}] \t\n  foo \n   bar[{  bar baz  asd }]\n\nbaz \n   \n[{endcollapsespace}] bb  ", []confToken{
+		{ID: text, Value: "  aa\n\t "},
+		{ID: text, Value: " foo bar"},
+		{ID: tagName, Value: "bar"},
+		{ID: tagContents, Value: "baz  asd"},
+		{ID: text, Value: " baz "},
+		{ID: text, Value: " bb  "},
+	})
+	testScannerConfigurationSuccess(t, "[{collapsespace  }][{ collapsespace fobar }] [{space}]  aaa\n\r\t bbb  [{endcollapsespace  }]  [{endcollapsespace  baz}]", []confToken{
+		{ID: text, Value: " "},
+		{ID: text, Value: " "},
+		{ID: text, Value: " aaa bbb "},
+		{ID: text, Value: " "},
+	})
+}
+
+/*TestScannerCollapsespaceFailure ...
+ */
+func TestScannerConfigurationCollapsespaceFailure(t *testing.T) {
+	// incomplete collapsespace tag
+	testScannerConfigurationFailure(t, "[{collapsespace   ")
+
+	// incomplete endcollapsespace tag
+	testScannerConfigurationFailure(t, "[{collapsespace}]aaa[{endcollapsespace")
+
+	// missing endcollapsespace
+	testScannerConfigurationFailure(t, "[{collapsespace}] foobar")
+
+	// missing collapsespace
+	testScannerConfigurationFailure(t, "aaa[{endcollapsespace}]")
+
+	// missing the second endcollapsespace
+	testScannerConfigurationFailure(t, "[{collapsespace}][{collapsespace}]aaaa[{endcollapsespace}]")
+}
+
+/*TestScannerPlainSuccess ...
+ */
+func TestScannerConfigurationPlainSuccess(t *testing.T) {
+	testScannerConfigurationSuccess(t, "[{plain}][{endplain}]", nil)
+	testScannerConfigurationSuccess(t, "[{plain}][{foo bar}]asdf[{endplain}]", []confToken{
+		{ID: text, Value: "[{foo bar}]asdf"},
+	})
+	testScannerConfigurationSuccess(t, "[{plain}][{foo[{endplain}]", []confToken{
+		{ID: text, Value: "[{foo"},
+	})
+	testScannerConfigurationSuccess(t, "aa[{plain}]bbb[{cc}][{endplain}][{plain}]dsff[{endplain}]", []confToken{
+		{ID: text, Value: "aa"},
+		{ID: text, Value: "bbb[{cc}]"},
+		{ID: text, Value: "dsff"},
+	})
+	testScannerConfigurationSuccess(t, "mmm[{plain}]aa[{ bar [{%% }baz[{endplain}]nnn", []confToken{
+		{ID: text, Value: "mmm"},
+		{ID: text, Value: "aa[{ bar [{%% }baz"},
+		{ID: text, Value: "nnn"},
+	})
+	testScannerConfigurationSuccess(t, "[{ plain dsd }]0[{comment}]123[{endcomment}]45[{ endplain aaa }]", []confToken{
+		{ID: text, Value: "0[{comment}]123[{endcomment}]45"},
+	})
+}
+
+/*TestScannerPlainFailure ...
+ */
+func TestScannerConfigurationPlainFailure(t *testing.T) {
+	testScannerConfigurationFailure(t, "[{plain}]sdfds")
+	testScannerConfigurationFailure(t, "[{plain}]aaaa%[{endplain")
+	testScannerConfigurationFailure(t, "[{plain}][{endplain%")
+}
+
+/*TestScannerCommentSuccess ...
+ */
+func TestScannerConfigurationCommentSuccess(t *testing.T) {
+	testScannerConfigurationSuccess(t, "[{comment}][{endcomment}]", nil)
+	testScannerConfigurationSuccess(t, "[{comment}]foo[{endcomment}]", nil)
+	testScannerConfigurationSuccess(t, "[{comment}]foo[{endcomment}][{comment}]sss[{endcomment}]", nil)
+	testScannerConfigurationSuccess(t, "[{comment}]foo[{bar}][{endcomment}]", nil)
+	testScannerConfigurationSuccess(t, "[{comment}]foo[{bar [{endcomment}]", nil)
+	testScannerConfigurationSuccess(t, "[{comment}]foo[{bar&^[{endcomment}]", nil)
+	testScannerConfigurationSuccess(t, "[{comment}]foo[{ bar\n\rs%[{endcomment}]", nil)
+	testScannerConfigurationSuccess(t, "xx[{x}]www[{ comment aux data }]aaa[{ comment }][{ endcomment }]yy", []confToken{
+		{ID: text, Value: "xx"},
+		{ID: tagName, Value: "x"},
+		{ID: tagContents, Value: ""},
+		{ID: text, Value: "www"},
+		{ID: text, Value: "yy"},
+	})
+}
+
+/*TestScannerCommentFailure ...
+ */
+func TestScannerConfigurationCommentFailure(t *testing.T) {
+	testScannerConfigurationFailure(t, "[{comment}]...no endcomment")
+	testScannerConfigurationFailure(t, "[{ comment }]foobar[{ endcomment")
+}
+
+func TestScannerConfigurationSuccess(t *testing.T) {
+	testScannerConfigurationSuccess(t, "", nil)
+	testScannerConfigurationSuccess(t, "a}]{foo}bar", []confToken{
+		{ID: text, Value: "a}]{foo}bar"},
+	})
+	testScannerConfigurationSuccess(t, "[{ foo bar baz(a, b, 123) }]", []confToken{
+		{ID: tagName, Value: "foo"},
+		{ID: tagContents, Value: "bar baz(a, b, 123)"},
+	})
+	testScannerConfigurationSuccess(t, "foo[{bar}]baz", []confToken{
+		{ID: text, Value: "foo"},
+		{ID: tagName, Value: "bar"},
+		{ID: tagContents, Value: ""},
+		{ID: text, Value: "baz"},
+	})
+	testScannerConfigurationSuccess(t, "{{[{\n\r\tfoo bar\n\rbaz%%\n   \r }]}", []confToken{
+		{ID: text, Value: "{{"},
+		{ID: tagName, Value: "foo"},
+		{ID: tagContents, Value: "bar\n\rbaz%%"},
+		{ID: text, Value: "}"},
+	})
+	testScannerConfigurationSuccess(t, "[{}]", []confToken{
+		{ID: tagName, Value: ""},
+		{ID: tagContents, Value: ""},
+	})
+	testScannerConfigurationSuccess(t, "[{%aaa bb}]", []confToken{
+		{ID: tagName, Value: ""},
+		{ID: tagContents, Value: "%aaa bb"},
+	})
+	testScannerConfigurationSuccess(t, "foo[{ bar }][{ baz aa (123)}]321", []confToken{
+		{ID: text, Value: "foo"},
+		{ID: tagName, Value: "bar"},
+		{ID: tagContents, Value: ""},
+		{ID: tagName, Value: "baz"},
+		{ID: tagContents, Value: "aa (123)"},
+		{ID: text, Value: "321"},
+	})
+}
+
+/*TestScannerConfigurationFailure ...
+ */
+func TestScannerConfigurationFailure(t *testing.T) {
+	testScannerConfigurationFailure(t, "a[{")
+	testScannerConfigurationFailure(t, "a[{foo")
+	testScannerConfigurationFailure(t, "a[{% }foo")
+	testScannerConfigurationFailure(t, "a[{ foo %")
+	testScannerConfigurationFailure(t, "b[{ fo() }]bar")
+	testScannerConfigurationFailure(t, "aa[{ foo bar")
+}
+
+func testScannerConfigurationFailure(t *testing.T, str string) {
+	r := bytes.NewBufferString(str)
+	s := newScannerWithTagConf(r, "memory", "[{", "}]")
+	var tokens []confToken
+	for s.Next() {
+		id := s.Token().ID
+		val := string(s.Token().Value)
+		fmt.Printf("%d %s", id, val)
+		tokens = append(tokens, confToken{
+			ID:    s.Token().ID,
+			Value: string(s.Token().Value),
+		})
+	}
+	if err := s.LastError(); err == nil {
+		t.Fatalf("expecting error when scanning %q. got tokens %v", str, tokens)
+	}
+}
+
+func testScannerConfigurationSuccess(t *testing.T, str string, expectedTokens []confToken) {
+	r := bytes.NewBufferString(str)
+	s := newScannerWithTagConf(r, "memory", "[{", "}]")
+	var tokens []confToken
+	for s.Next() {
+		tokens = append(tokens, confToken{
+			ID:    s.Token().ID,
+			Value: string(s.Token().Value),
+		})
+	}
+	if err := s.LastError(); err != nil {
+		t.Fatalf("unexpected error: %s. str=%q", err, str)
+	}
+	if !reflect.DeepEqual(tokens, expectedTokens) {
+		t.Fatalf("unexpected tokens %v. Expecting %v. str=%q", tokens, expectedTokens, str)
+	}
+}
+
+// /*TestScannerConfigurationSuccessTest ...
+//  */
+// func TestScannerConfigurationSuccess(t *testing.T) {
+// 	testScannerConfigurationSuccess(t, "", nil)
+// 	testScannerConfigurationSuccess(t, "a%]{foo}bar", []confToken{
+// 		{ID: text, Value: "a%]{foo}bar"},
+// 	})
+// 	testScannerConfigurationSuccess(t, "[% foo bar baz(a, b, 123) %]", []confToken{
+// 		{ID: tagName, Value: "foo"},
+// 		{ID: tagContents, Value: "bar baz(a, b, 123)"},
+// 	})
+// 	testScannerConfigurationSuccess(t, "foo[%bar%]baz", []confToken{
+// 		{ID: text, Value: "foo"},
+// 		{ID: tagName, Value: "bar"},
+// 		{ID: tagContents, Value: ""},
+// 		{ID: text, Value: "baz"},
+// 	})
+// 	testScannerConfigurationSuccess(t, "{{[%\n\r\tfoo bar\n\rbaz%%\n   \r }]}", []confToken{
+// 		{ID: text, Value: "{{"},
+// 		{ID: tagName, Value: "foo"},
+// 		{ID: tagContents, Value: "bar\n\rbaz%%"},
+// 		{ID: text, Value: "}"},
+// 	})
+// 	testScannerConfigurationSuccess(t, "[%%]", []confToken{
+// 		{ID: tagName, Value: ""},
+// 		{ID: tagContents, Value: ""},
+// 	})
+// 	testScannerConfigurationSuccess(t, "[%%aaa bb%]", []confToken{
+// 		{ID: tagName, Value: ""},
+// 		{ID: tagContents, Value: "%aaa bb"},
+// 	})
+// 	testScannerConfigurationSuccess(t, "foo[% bar %][% baz aa (123)%]321", []confToken{
+// 		{ID: text, Value: "foo"},
+// 		{ID: tagName, Value: "bar"},
+// 		{ID: tagContents, Value: ""},
+// 		{ID: tagName, Value: "baz"},
+// 		{ID: tagContents, Value: "aa (123)"},
+// 		{ID: text, Value: "321"},
+// 	})
+// 	testScannerConfigurationSuccess(t, "  aa\n\t [%stripspace%] \t\n  f\too \n   b  ar \n\r\t [%  bar baz  asd %]\n\nbaz \n\t \taaa  \n[%endstripspace%] bb  ", []confToken{
+// 		{ID: text, Value: "  aa\n\t "},
+// 		{ID: text, Value: "f\toob  ar"},
+// 		{ID: tagName, Value: "bar"},
+// 		{ID: tagContents, Value: "baz  asd"},
+// 		{ID: text, Value: "bazaaa"},
+// 		{ID: text, Value: " bb  "},
+// 	})
+// }
+
+/*TestCrash ...
+ */
+func TestCrash(t *testing.T) {
+
+	var source = `This is a base page template. All the other template pages implement this interface.
+
+{% interface
+Page {
+	Title()
+	Body()
+}
+}]
+
+
+Page prints a page implementing Page interface.
+[{ func PageTemplate(p Page) }]
+<html>
+	<head>
+		<title>{%= p.Title() }]</title>
+	</head>
+	<body>
+		<div>
+			<a href="/">return to main page</a>
+		</div>
+		[{= p.Body() }]
+	</body>
+</html>
+[{ endfunc }]
+
+
+Base page implementation. Other pages may inherit from it if they need
+overriding only certain Page methods
+[{ code type BasePage struct {} }]
+[{ func (p *BasePage) Title() }]This is a base title[{ endfunc }]
+[{ func (p *BasePage) Body() }]This is a base body[{ endfunc }]
+}`
+	r := bytes.NewBufferString(source)
+	s := newScannerWithTagConf(r, "memory", "[{", "}]")
+	var tokens []confToken
+	for s.Next() {
+		tokens = append(tokens, confToken{
+			ID:    s.Token().ID,
+			Value: string(s.Token().Value),
+		})
+	}
+	if err := s.LastError(); err != nil {
+		t.Fatalf("unexpected error: %s. str=%q", err, source)
+	}
+}
+
+type confToken struct {
+	ID    int
+	Value string
+}

--- a/qtc/scanner_with_conf_test.go
+++ b/qtc/scanner_with_conf_test.go
@@ -135,7 +135,7 @@ func TestScannerConfigurationPlainFailure(t *testing.T) {
 /*TestScannerCommentSuccess ...
  */
 func TestScannerConfigurationCommentSuccess(t *testing.T) {
-	testScannerConfigurationSuccess(t, "[{comment}]groumpf[{endcomment}]", nil)
+	testScannerConfigurationSuccess(t, "[{comment}][{endcomment}]", nil)
 	testScannerConfigurationSuccess(t, "[{comment}]foo[{endcomment}]", nil)
 	testScannerConfigurationSuccess(t, "[{comment}]foo[{endcomment}][{comment}]sss[{endcomment}]", nil)
 	testScannerConfigurationSuccess(t, "[{comment}]foo[{bar}][{endcomment}]", nil)

--- a/qtc/scanner_with_conf_test.go
+++ b/qtc/scanner_with_conf_test.go
@@ -10,7 +10,7 @@ import (
 /*TestScannerConfigurationTagNameWithDotAndEqual ..."
  */
 func TestScannerConfigurationTagNameWithDotAndEqual(t *testing.T) {
-	testScannerConfigurationSuccess(t, "[{foo.bar.34 baz aaa}] awer[{ aa= }]",
+	testScannerConfigurationSuccess(t, "[%foo.bar.34 baz aaa%] awer[% aa= %]",
 		[]confToken{
 			{ID: tagName, Value: "foo.bar.34"},
 			{ID: tagContents, Value: "baz aaa"},
@@ -23,7 +23,7 @@ func TestScannerConfigurationTagNameWithDotAndEqual(t *testing.T) {
 /*TestScannerConfigurationStripspaceSuccess ...
  */
 func TestScannerConfigurationStripspaceSuccess(t *testing.T) {
-	testScannerConfigurationSuccess(t, "  aa\n\t [{stripspace}] \t\n  f\too \n   b  ar \n\r\t [{  bar baz  asd }]\n\nbaz \n\t \taaa  \n[{endstripspace}] bb  ", []confToken{
+	testScannerConfigurationSuccess(t, "  aa\n\t [%stripspace%] \t\n  f\too \n   b  ar \n\r\t [%  bar baz  asd %]\n\nbaz \n\t \taaa  \n[%endstripspace%] bb  ", []confToken{
 		{ID: text, Value: "  aa\n\t "},
 		{ID: text, Value: "f\toob  ar"},
 		{ID: tagName, Value: "bar"},
@@ -31,13 +31,13 @@ func TestScannerConfigurationStripspaceSuccess(t *testing.T) {
 		{ID: text, Value: "bazaaa"},
 		{ID: text, Value: " bb  "},
 	})
-	testScannerConfigurationSuccess(t, "[{stripspace  }][{ stripspace fobar }] [{space}]  a\taa\n\r\t bb  b  [{endstripspace  }]  [{endstripspace  baz}]", []confToken{
+	testScannerConfigurationSuccess(t, "[%stripspace  %][% stripspace fobar %] [%space%]  a\taa\n\r\t bb  b  [%endstripspace  %]  [%endstripspace  baz%]", []confToken{
 		{ID: text, Value: " "},
 		{ID: text, Value: "a\taabb  b"},
 	})
 
 	// sripspace wins over collapsespace
-	testScannerConfigurationSuccess(t, "[{stripspace}] [{collapsespace}]foo\n\t bar[{endcollapsespace}] \r\n\t [{endstripspace}]", []confToken{
+	testScannerConfigurationSuccess(t, "[%stripspace%] [%collapsespace%]foo\n\t bar[%endcollapsespace%] \r\n\t [%endstripspace%]", []confToken{
 		{ID: text, Value: "foobar"},
 	})
 }
@@ -46,25 +46,25 @@ func TestScannerConfigurationStripspaceSuccess(t *testing.T) {
  */
 func TestScannerConfigurationStripspaceFailure(t *testing.T) {
 	// incomplete stripspace tag
-	testScannerConfigurationFailure(t, "[{stripspace   ")
+	testScannerConfigurationFailure(t, "[%stripspace   ")
 
 	// incomplete endstripspace tag
-	testScannerConfigurationFailure(t, "[{stripspace}]aaa[{endstripspace")
+	testScannerConfigurationFailure(t, "[%stripspace%]aaa[%endstripspace")
 
 	// missing endstripspace
-	testScannerConfigurationFailure(t, "[{stripspace}] foobar")
+	testScannerConfigurationFailure(t, "[%stripspace%] foobar")
 
 	// missing stripspace
-	testScannerConfigurationFailure(t, "aaa[{endstripspace}]")
+	testScannerConfigurationFailure(t, "aaa[%endstripspace%]")
 
 	// missing the second endstripspace
-	testScannerConfigurationFailure(t, "[{stripspace}][{stripspace}]aaaa[{endstripspace}]")
+	testScannerConfigurationFailure(t, "[%stripspace%][%stripspace%]aaaa[%endstripspace%]")
 }
 
 /*TestScannerConfigurationCollapsespaceSuccess ...
  */
 func TestScannerConfigurationCollapsespaceSuccess(t *testing.T) {
-	testScannerConfigurationSuccess(t, "  aa\n\t [{collapsespace}] \t\n  foo \n   bar[{  bar baz  asd }]\n\nbaz \n   \n[{endcollapsespace}] bb  ", []confToken{
+	testScannerConfigurationSuccess(t, "  aa\n\t [%collapsespace%] \t\n  foo \n   bar[%  bar baz  asd %]\n\nbaz \n   \n[%endcollapsespace%] bb  ", []confToken{
 		{ID: text, Value: "  aa\n\t "},
 		{ID: text, Value: " foo bar"},
 		{ID: tagName, Value: "bar"},
@@ -72,7 +72,7 @@ func TestScannerConfigurationCollapsespaceSuccess(t *testing.T) {
 		{ID: text, Value: " baz "},
 		{ID: text, Value: " bb  "},
 	})
-	testScannerConfigurationSuccess(t, "[{collapsespace  }][{ collapsespace fobar }] [{space}]  aaa\n\r\t bbb  [{endcollapsespace  }]  [{endcollapsespace  baz}]", []confToken{
+	testScannerConfigurationSuccess(t, "[%collapsespace  %][% collapsespace fobar %] [%space%]  aaa\n\r\t bbb  [%endcollapsespace  %]  [%endcollapsespace  baz%]", []confToken{
 		{ID: text, Value: " "},
 		{ID: text, Value: " "},
 		{ID: text, Value: " aaa bbb "},
@@ -84,65 +84,65 @@ func TestScannerConfigurationCollapsespaceSuccess(t *testing.T) {
  */
 func TestScannerConfigurationCollapsespaceFailure(t *testing.T) {
 	// incomplete collapsespace tag
-	testScannerConfigurationFailure(t, "[{collapsespace   ")
+	testScannerConfigurationFailure(t, "[%collapsespace   ")
 
 	// incomplete endcollapsespace tag
-	testScannerConfigurationFailure(t, "[{collapsespace}]aaa[{endcollapsespace")
+	testScannerConfigurationFailure(t, "[%collapsespace%]aaa[%endcollapsespace")
 
 	// missing endcollapsespace
-	testScannerConfigurationFailure(t, "[{collapsespace}] foobar")
+	testScannerConfigurationFailure(t, "[%collapsespace%] foobar")
 
 	// missing collapsespace
-	testScannerConfigurationFailure(t, "aaa[{endcollapsespace}]")
+	testScannerConfigurationFailure(t, "aaa[%endcollapsespace%]")
 
 	// missing the second endcollapsespace
-	testScannerConfigurationFailure(t, "[{collapsespace}][{collapsespace}]aaaa[{endcollapsespace}]")
+	testScannerConfigurationFailure(t, "[%collapsespace%][%collapsespace%]aaaa[%endcollapsespace%]")
 }
 
 /*TestScannerPlainSuccess ...
  */
 func TestScannerConfigurationPlainSuccess(t *testing.T) {
-	testScannerConfigurationSuccess(t, "[{plain}][{endplain}]", nil)
-	testScannerConfigurationSuccess(t, "[{plain}][{foo bar}]asdf[{endplain}]", []confToken{
-		{ID: text, Value: "[{foo bar}]asdf"},
+	testScannerConfigurationSuccess(t, "[%plain%][%endplain%]", nil)
+	testScannerConfigurationSuccess(t, "[%plain%][%foo bar%]asdf[%endplain%]", []confToken{
+		{ID: text, Value: "[%foo bar%]asdf"},
 	})
-	testScannerConfigurationSuccess(t, "[{plain}][{foo[{endplain}]", []confToken{
-		{ID: text, Value: "[{foo"},
+	testScannerConfigurationSuccess(t, "[%plain%][%foo[%endplain%]", []confToken{
+		{ID: text, Value: "[%foo"},
 	})
-	testScannerConfigurationSuccess(t, "aa[{plain}]bbb[{cc}][{endplain}][{plain}]dsff[{endplain}]", []confToken{
+	testScannerConfigurationSuccess(t, "aa[%plain%]bbb[%cc%][%endplain%][%plain%]dsff[%endplain%]", []confToken{
 		{ID: text, Value: "aa"},
-		{ID: text, Value: "bbb[{cc}]"},
+		{ID: text, Value: "bbb[%cc%]"},
 		{ID: text, Value: "dsff"},
 	})
-	testScannerConfigurationSuccess(t, "mmm[{plain}]aa[{ bar [{%% }baz[{endplain}]nnn", []confToken{
+	testScannerConfigurationSuccess(t, "mmm[%plain%]aa[% bar [%%% }baz[%endplain%]nnn", []confToken{
 		{ID: text, Value: "mmm"},
-		{ID: text, Value: "aa[{ bar [{%% }baz"},
+		{ID: text, Value: "aa[% bar [%%% }baz"},
 		{ID: text, Value: "nnn"},
 	})
-	testScannerConfigurationSuccess(t, "[{ plain dsd }]0[{comment}]123[{endcomment}]45[{ endplain aaa }]", []confToken{
-		{ID: text, Value: "0[{comment}]123[{endcomment}]45"},
+	testScannerConfigurationSuccess(t, "[% plain dsd %]0[%comment%]123[%endcomment%]45[% endplain aaa %]", []confToken{
+		{ID: text, Value: "0[%comment%]123[%endcomment%]45"},
 	})
 }
 
 /*TestScannerPlainFailure ...
  */
 func TestScannerConfigurationPlainFailure(t *testing.T) {
-	testScannerConfigurationFailure(t, "[{plain}]sdfds")
-	testScannerConfigurationFailure(t, "[{plain}]aaaa%[{endplain")
-	testScannerConfigurationFailure(t, "[{plain}][{endplain%")
+	testScannerConfigurationFailure(t, "[%plain%]sdfds")
+	testScannerConfigurationFailure(t, "[%plain%]aaaa%[%endplain")
+	testScannerConfigurationFailure(t, "[%plain%][%endplain%")
 }
 
 /*TestScannerCommentSuccess ...
  */
 func TestScannerConfigurationCommentSuccess(t *testing.T) {
-	testScannerConfigurationSuccess(t, "[{comment}][{endcomment}]", nil)
-	testScannerConfigurationSuccess(t, "[{comment}]foo[{endcomment}]", nil)
-	testScannerConfigurationSuccess(t, "[{comment}]foo[{endcomment}][{comment}]sss[{endcomment}]", nil)
-	testScannerConfigurationSuccess(t, "[{comment}]foo[{bar}][{endcomment}]", nil)
-	testScannerConfigurationSuccess(t, "[{comment}]foo[{bar [{endcomment}]", nil)
-	testScannerConfigurationSuccess(t, "[{comment}]foo[{bar&^[{endcomment}]", nil)
-	testScannerConfigurationSuccess(t, "[{comment}]foo[{ bar\n\rs%[{endcomment}]", nil)
-	testScannerConfigurationSuccess(t, "xx[{x}]www[{ comment aux data }]aaa[{ comment }][{ endcomment }]yy", []confToken{
+	testScannerConfigurationSuccess(t, "[%comment%][%endcomment%]", nil)
+	testScannerConfigurationSuccess(t, "[%comment%]foo[%endcomment%]", nil)
+	testScannerConfigurationSuccess(t, "[%comment%]foo[%endcomment%][%comment%]sss[%endcomment%]", nil)
+	testScannerConfigurationSuccess(t, "[%comment%]foo[%bar%][%endcomment%]", nil)
+	testScannerConfigurationSuccess(t, "[%comment%]foo[%bar [%endcomment%]", nil)
+	testScannerConfigurationSuccess(t, "[%comment%]foo[%bar&^[%endcomment%]", nil)
+	testScannerConfigurationSuccess(t, "[%comment%]foo[% bar\n\rs%[%endcomment%]", nil)
+	testScannerConfigurationSuccess(t, "xx[%x%]www[% comment aux data %]aaa[% comment %][% endcomment %]yy", []confToken{
 		{ID: text, Value: "xx"},
 		{ID: tagName, Value: "x"},
 		{ID: tagContents, Value: ""},
@@ -154,40 +154,40 @@ func TestScannerConfigurationCommentSuccess(t *testing.T) {
 /*TestScannerCommentFailure ...
  */
 func TestScannerConfigurationCommentFailure(t *testing.T) {
-	testScannerConfigurationFailure(t, "[{comment}]...no endcomment")
-	testScannerConfigurationFailure(t, "[{ comment }]foobar[{ endcomment")
+	testScannerConfigurationFailure(t, "[%comment%]...no endcomment")
+	testScannerConfigurationFailure(t, "[% comment %]foobar[% endcomment")
 }
 
 func TestScannerConfigurationSuccess(t *testing.T) {
 	testScannerConfigurationSuccess(t, "", nil)
-	testScannerConfigurationSuccess(t, "a}]{foo}bar", []confToken{
-		{ID: text, Value: "a}]{foo}bar"},
+	testScannerConfigurationSuccess(t, "a%]{foo}bar", []confToken{
+		{ID: text, Value: "a%]{foo}bar"},
 	})
-	testScannerConfigurationSuccess(t, "[{ foo bar baz(a, b, 123) }]", []confToken{
+	testScannerConfigurationSuccess(t, "[% foo bar baz(a, b, 123) %]", []confToken{
 		{ID: tagName, Value: "foo"},
 		{ID: tagContents, Value: "bar baz(a, b, 123)"},
 	})
-	testScannerConfigurationSuccess(t, "foo[{bar}]baz", []confToken{
+	testScannerConfigurationSuccess(t, "foo[%bar%]baz", []confToken{
 		{ID: text, Value: "foo"},
 		{ID: tagName, Value: "bar"},
 		{ID: tagContents, Value: ""},
 		{ID: text, Value: "baz"},
 	})
-	testScannerConfigurationSuccess(t, "{{[{\n\r\tfoo bar\n\rbaz%%\n   \r }]}", []confToken{
+	testScannerConfigurationSuccess(t, "{{[%\n\r\tfoo bar\n\rbaz%%\n   \r %]}", []confToken{
 		{ID: text, Value: "{{"},
 		{ID: tagName, Value: "foo"},
 		{ID: tagContents, Value: "bar\n\rbaz%%"},
 		{ID: text, Value: "}"},
 	})
-	testScannerConfigurationSuccess(t, "[{}]", []confToken{
+	testScannerConfigurationSuccess(t, "[%%]", []confToken{
 		{ID: tagName, Value: ""},
 		{ID: tagContents, Value: ""},
 	})
-	testScannerConfigurationSuccess(t, "[{%aaa bb}]", []confToken{
+	testScannerConfigurationSuccess(t, "[%%aaa bb%]", []confToken{
 		{ID: tagName, Value: ""},
 		{ID: tagContents, Value: "%aaa bb"},
 	})
-	testScannerConfigurationSuccess(t, "foo[{ bar }][{ baz aa (123)}]321", []confToken{
+	testScannerConfigurationSuccess(t, "foo[% bar %][% baz aa (123)%]321", []confToken{
 		{ID: text, Value: "foo"},
 		{ID: tagName, Value: "bar"},
 		{ID: tagContents, Value: ""},
@@ -200,17 +200,17 @@ func TestScannerConfigurationSuccess(t *testing.T) {
 /*TestScannerConfigurationFailure ...
  */
 func TestScannerConfigurationFailure(t *testing.T) {
-	testScannerConfigurationFailure(t, "a[{")
-	testScannerConfigurationFailure(t, "a[{foo")
-	testScannerConfigurationFailure(t, "a[{% }foo")
-	testScannerConfigurationFailure(t, "a[{ foo %")
-	testScannerConfigurationFailure(t, "b[{ fo() }]bar")
-	testScannerConfigurationFailure(t, "aa[{ foo bar")
+	testScannerConfigurationFailure(t, "a[%")
+	testScannerConfigurationFailure(t, "a[%foo")
+	testScannerConfigurationFailure(t, "a[%% }foo")
+	testScannerConfigurationFailure(t, "a[% foo %")
+	testScannerConfigurationFailure(t, "b[% fo() %]bar")
+	testScannerConfigurationFailure(t, "aa[% foo bar")
 }
 
 func testScannerConfigurationFailure(t *testing.T, str string) {
 	r := bytes.NewBufferString(str)
-	s := newScannerWithTagConf(r, "memory", "[{", "}]")
+	s := newScannerWithTagConf(r, "memory", "[%", "%]")
 	var tokens []confToken
 	for s.Next() {
 		id := s.Token().ID
@@ -228,7 +228,7 @@ func testScannerConfigurationFailure(t *testing.T, str string) {
 
 func testScannerConfigurationSuccess(t *testing.T, str string, expectedTokens []confToken) {
 	r := bytes.NewBufferString(str)
-	s := newScannerWithTagConf(r, "memory", "[{", "}]")
+	s := newScannerWithTagConf(r, "memory", "[%", "%]")
 	var tokens []confToken
 	for s.Next() {
 		tokens = append(tokens, confToken{
@@ -261,7 +261,7 @@ func testScannerConfigurationSuccess(t *testing.T, str string, expectedTokens []
 // 		{ID: tagContents, Value: ""},
 // 		{ID: text, Value: "baz"},
 // 	})
-// 	testScannerConfigurationSuccess(t, "{{[%\n\r\tfoo bar\n\rbaz%%\n   \r }]}", []confToken{
+// 	testScannerConfigurationSuccess(t, "{{[%\n\r\tfoo bar\n\rbaz%%\n   \r %]}", []confToken{
 // 		{ID: text, Value: "{{"},
 // 		{ID: tagName, Value: "foo"},
 // 		{ID: tagContents, Value: "bar\n\rbaz%%"},
@@ -304,33 +304,33 @@ Page {
 	Title()
 	Body()
 }
-}]
+%]
 
 
 Page prints a page implementing Page interface.
-[{ func PageTemplate(p Page) }]
+[% func PageTemplate(p Page) %]
 <html>
 	<head>
-		<title>{%= p.Title() }]</title>
+		<title>{%= p.Title() %]</title>
 	</head>
 	<body>
 		<div>
 			<a href="/">return to main page</a>
 		</div>
-		[{= p.Body() }]
+		[%= p.Body() %]
 	</body>
 </html>
-[{ endfunc }]
+[% endfunc %]
 
 
 Base page implementation. Other pages may inherit from it if they need
 overriding only certain Page methods
-[{ code type BasePage struct {} }]
-[{ func (p *BasePage) Title() }]This is a base title[{ endfunc }]
-[{ func (p *BasePage) Body() }]This is a base body[{ endfunc }]
+[% code type BasePage struct {} %]
+[% func (p *BasePage) Title() %]This is a base title[% endfunc %]
+[% func (p *BasePage) Body() %]This is a base body[% endfunc %]
 }`
 	r := bytes.NewBufferString(source)
-	s := newScannerWithTagConf(r, "memory", "[{", "}]")
+	s := newScannerWithTagConf(r, "memory", "[%", "%]")
 	var tokens []confToken
 	for s.Next() {
 		tokens = append(tokens, confToken{

--- a/qtc/scanner_with_conf_test.go
+++ b/qtc/scanner_with_conf_test.go
@@ -135,7 +135,7 @@ func TestScannerConfigurationPlainFailure(t *testing.T) {
 /*TestScannerCommentSuccess ...
  */
 func TestScannerConfigurationCommentSuccess(t *testing.T) {
-	testScannerConfigurationSuccess(t, "[{comment}][{endcomment}]", nil)
+	testScannerConfigurationSuccess(t, "[{comment}]groumpf[{endcomment}]", nil)
 	testScannerConfigurationSuccess(t, "[{comment}]foo[{endcomment}]", nil)
 	testScannerConfigurationSuccess(t, "[{comment}]foo[{endcomment}][{comment}]sss[{endcomment}]", nil)
 	testScannerConfigurationSuccess(t, "[{comment}]foo[{bar}][{endcomment}]", nil)


### PR DESCRIPTION
This pull request allows to configure starting an ending tag delimiters (default "{%" and "%}" accordingly)
2 arguments have been added to the qtc compiler : 

- "sTag" for the starting tag delimiter : `-sTag '{%'`
- "eTag" for the starting tag delimiter : `-sTag '%}'`

Delimiters mus respect following rules : 
- each delimiter must be exactly 2 characters long
- starting delimiter's last char and ending delimiter's first char must be identical, eg
     - '[-' and '-]' are OK
     - '[-' and '%]' are not allowed
- each delimiter cannot consist of the same char repitition, eg
    - '{%' is OK
    - '{{' is KO

These rules are for compatibility reasons with original templates parsing.




 