### PR TITLE
Don't output whitespace before //line

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -801,7 +801,7 @@ func (p *parser) Printf(format string, args ...interface{}) {
 		return
 	}
 	w := p.w
-	fmt.Fprintf(w, "%s", p.prefix)
+	// line comments are required to start at the beginning of the line
 	p.s.WriteLineComment(w)
 	fmt.Fprintf(w, "%s", p.prefix)
 	fmt.Fprintf(w, format, args...)

--- a/testdata/qtc/test.qtpl.expected
+++ b/testdata/qtc/test.qtpl.expected
@@ -43,233 +43,233 @@ type FooArgs struct {
 
 //line test.qtpl:24
 func StreamFoo(qw422016 *qt422016.Writer, a []FooArgs) {
-	//line test.qtpl:24
+//line test.qtpl:24
 	qw422016.N().S(`
 	<h1>Hello, I'm Foo!</h1>
 	<div>
 		My args are:
 		`)
-	//line test.qtpl:28
+//line test.qtpl:28
 	if len(a) == 0 {
-		//line test.qtpl:28
+//line test.qtpl:28
 		qw422016.N().S(`
 			no args!
 		`)
-		//line test.qtpl:30
+//line test.qtpl:30
 	} else if len(a) == 1 {
-		//line test.qtpl:30
+//line test.qtpl:30
 		qw422016.N().S(`
 			a single arg: `)
-		//line test.qtpl:31
+//line test.qtpl:31
 		streamprintArgs(qw422016, 0, &a[0])
-		//line test.qtpl:31
+//line test.qtpl:31
 		qw422016.N().S(`
 		`)
-		//line test.qtpl:32
+//line test.qtpl:32
 	} else {
-		//line test.qtpl:32
+//line test.qtpl:32
 		qw422016.N().S(`
 			<ul>
 			`)
-		//line test.qtpl:34
+//line test.qtpl:34
 		for i, aa := range a {
-			//line test.qtpl:34
+//line test.qtpl:34
 			qw422016.N().S(`
 				`)
-			//line test.qtpl:35
+//line test.qtpl:35
 			if i >= 42 {
-				//line test.qtpl:35
+//line test.qtpl:35
 				qw422016.N().S(`
 					There are other args, but only the first 42 of them are shown
 					`)
-				//line test.qtpl:37
+//line test.qtpl:37
 				break
-				//line test.qtpl:40
+//line test.qtpl:40
 			} else if aa.N == 3 {
-				//line test.qtpl:40
+//line test.qtpl:40
 				qw422016.N().S(`
 					`)
-				//line test.qtpl:41
+//line test.qtpl:41
 				continue
-				//line test.qtpl:43
+//line test.qtpl:43
 			}
-			//line test.qtpl:43
+//line test.qtpl:43
 			qw422016.N().S(`
 
 				no html encoding: `)
-			//line test.qtpl:45
+//line test.qtpl:45
 			streamprintArgs(qw422016, i, &aa)
-			//line test.qtpl:45
+//line test.qtpl:45
 			qw422016.N().S(`
 				html encoding: `)
-			//line test.qtpl:46
+//line test.qtpl:46
 			{
-				//line test.qtpl:46
+//line test.qtpl:46
 				qb422016 := qt422016.AcquireByteBuffer()
-				//line test.qtpl:46
+//line test.qtpl:46
 				writeprintArgs(qb422016, i, &aa)
-				//line test.qtpl:46
+//line test.qtpl:46
 				qw422016.E().Z(qb422016.B)
-				//line test.qtpl:46
+//line test.qtpl:46
 				qt422016.ReleaseByteBuffer(qb422016)
-				//line test.qtpl:46
+//line test.qtpl:46
 			}
-			//line test.qtpl:46
+//line test.qtpl:46
 			qw422016.N().S(`
 				url encoding: `)
-			//line test.qtpl:47
+//line test.qtpl:47
 			{
-				//line test.qtpl:47
+//line test.qtpl:47
 				qb422016 := qt422016.AcquireByteBuffer()
-				//line test.qtpl:47
+//line test.qtpl:47
 				writeprintArgs(qb422016, i, &aa)
-				//line test.qtpl:47
+//line test.qtpl:47
 				qw422016.N().UZ(qb422016.B)
-				//line test.qtpl:47
+//line test.qtpl:47
 				qt422016.ReleaseByteBuffer(qb422016)
-				//line test.qtpl:47
+//line test.qtpl:47
 			}
-			//line test.qtpl:47
+//line test.qtpl:47
 			qw422016.N().S(`
 				html-encoded url encoding: `)
-			//line test.qtpl:48
+//line test.qtpl:48
 			{
-				//line test.qtpl:48
+//line test.qtpl:48
 				qb422016 := qt422016.AcquireByteBuffer()
-				//line test.qtpl:48
+//line test.qtpl:48
 				writeprintArgs(qb422016, i, &aa)
-				//line test.qtpl:48
+//line test.qtpl:48
 				qw422016.N().UZ(qb422016.B)
-				//line test.qtpl:48
+//line test.qtpl:48
 				qt422016.ReleaseByteBuffer(qb422016)
-				//line test.qtpl:48
+//line test.qtpl:48
 			}
-			//line test.qtpl:48
+//line test.qtpl:48
 			qw422016.N().S(`
 				quoted json string: `)
-			//line test.qtpl:49
+//line test.qtpl:49
 			{
-				//line test.qtpl:49
+//line test.qtpl:49
 				qb422016 := qt422016.AcquireByteBuffer()
-				//line test.qtpl:49
+//line test.qtpl:49
 				writeprintArgs(qb422016, i, &aa)
-				//line test.qtpl:49
+//line test.qtpl:49
 				qw422016.N().QZ(qb422016.B)
-				//line test.qtpl:49
+//line test.qtpl:49
 				qt422016.ReleaseByteBuffer(qb422016)
-				//line test.qtpl:49
+//line test.qtpl:49
 			}
-			//line test.qtpl:49
+//line test.qtpl:49
 			qw422016.N().S(`
 				html-encoded quoted json string: `)
-			//line test.qtpl:50
+//line test.qtpl:50
 			{
-				//line test.qtpl:50
+//line test.qtpl:50
 				qb422016 := qt422016.AcquireByteBuffer()
-				//line test.qtpl:50
+//line test.qtpl:50
 				writeprintArgs(qb422016, i, &aa)
-				//line test.qtpl:50
+//line test.qtpl:50
 				qw422016.E().QZ(qb422016.B)
-				//line test.qtpl:50
+//line test.qtpl:50
 				qt422016.ReleaseByteBuffer(qb422016)
-				//line test.qtpl:50
+//line test.qtpl:50
 			}
-			//line test.qtpl:50
+//line test.qtpl:50
 			qw422016.N().S(`
 				unquoted json string: `)
-			//line test.qtpl:51
+//line test.qtpl:51
 			{
-				//line test.qtpl:51
+//line test.qtpl:51
 				qb422016 := qt422016.AcquireByteBuffer()
-				//line test.qtpl:51
+//line test.qtpl:51
 				writeprintArgs(qb422016, i, &aa)
-				//line test.qtpl:51
+//line test.qtpl:51
 				qw422016.N().JZ(qb422016.B)
-				//line test.qtpl:51
+//line test.qtpl:51
 				qt422016.ReleaseByteBuffer(qb422016)
-				//line test.qtpl:51
+//line test.qtpl:51
 			}
-			//line test.qtpl:51
+//line test.qtpl:51
 			qw422016.N().S(`
 				html-encoded unquoted json string: `)
-			//line test.qtpl:52
+//line test.qtpl:52
 			{
-				//line test.qtpl:52
+//line test.qtpl:52
 				qb422016 := qt422016.AcquireByteBuffer()
-				//line test.qtpl:52
+//line test.qtpl:52
 				writeprintArgs(qb422016, i, &aa)
-				//line test.qtpl:52
+//line test.qtpl:52
 				qw422016.E().JZ(qb422016.B)
-				//line test.qtpl:52
+//line test.qtpl:52
 				qt422016.ReleaseByteBuffer(qb422016)
-				//line test.qtpl:52
+//line test.qtpl:52
 			}
-			//line test.qtpl:52
+//line test.qtpl:52
 			qw422016.N().S(`
 
 				Arbitrary Go code may be inserted here: `)
-			//line test.qtpl:54
+//line test.qtpl:54
 			str := strconv.Itoa(i + 42)
 
-			//line test.qtpl:54
+//line test.qtpl:54
 			qw422016.N().S(`
 				str = `)
-			//line test.qtpl:55
+//line test.qtpl:55
 			qw422016.E().S(fmt.Sprintf("this html will be escaped <b>%s</b>", str))
-			//line test.qtpl:55
+//line test.qtpl:55
 			qw422016.N().S(`
 			`)
-			//line test.qtpl:56
+//line test.qtpl:56
 		}
-		//line test.qtpl:56
+//line test.qtpl:56
 		qw422016.N().S(`
 			</ul>
 		`)
-		//line test.qtpl:58
+//line test.qtpl:58
 	}
-	//line test.qtpl:58
+//line test.qtpl:58
 	qw422016.N().S(`
 	</div>
 	`)
-	//line test.qtpl:60
+//line test.qtpl:60
 	qw422016.N().S(`
 		Arbitrary tags are treated as plaintext inside plain.
 		For instance, {% foo %} {% bar %} {% for %}
 		{% func %} {% code %} {% return %} {% break %} {% comment %}
 		and even {% unclosed tag
 	`)
-	//line test.qtpl:65
+//line test.qtpl:65
 	qw422016.N().S(`
 	`)
-	//line test.qtpl:66
+//line test.qtpl:66
 	qw422016.N().S(` Leading and trailing space between lines and tags is collapsed inside collapsespace unless `)
-	//line test.qtpl:68
+//line test.qtpl:68
 	qw422016.N().S(` `)
-	//line test.qtpl:68
+//line test.qtpl:68
 	qw422016.N().S(` or `)
-	//line test.qtpl:68
+//line test.qtpl:68
 	qw422016.N().S(`
 `)
-	//line test.qtpl:68
+//line test.qtpl:68
 	qw422016.N().S(` is used `)
-	//line test.qtpl:69
+//line test.qtpl:69
 	qw422016.N().S(`
 	`)
-	//line test.qtpl:70
+//line test.qtpl:70
 	qw422016.N().S(`Leading and trailing space between lines and tags is completelyremoved unless`)
-	//line test.qtpl:72
+//line test.qtpl:72
 	qw422016.N().S(` `)
-	//line test.qtpl:72
+//line test.qtpl:72
 	qw422016.N().S(`or`)
-	//line test.qtpl:72
+//line test.qtpl:72
 	qw422016.N().S(`
 `)
-	//line test.qtpl:72
+//line test.qtpl:72
 	qw422016.N().S(`is used`)
-	//line test.qtpl:73
+//line test.qtpl:73
 	qw422016.N().S(`
 	`)
-	//line test.qtpl:74
+//line test.qtpl:74
 	qw422016.N().S(`This is a test template file.
 All the lines outside func and code are just comments.
 
@@ -429,7 +429,7 @@ variadic function
 	{% endfor %}
 {% endfunc %}
 `)
-	//line test.qtpl:74
+//line test.qtpl:74
 	qw422016.N().S(`
 `)
 //line test.qtpl:75
@@ -437,26 +437,26 @@ variadic function
 
 //line test.qtpl:75
 func WriteFoo(qq422016 qtio422016.Writer, a []FooArgs) {
-	//line test.qtpl:75
+//line test.qtpl:75
 	qw422016 := qt422016.AcquireWriter(qq422016)
-	//line test.qtpl:75
+//line test.qtpl:75
 	StreamFoo(qw422016, a)
-	//line test.qtpl:75
+//line test.qtpl:75
 	qt422016.ReleaseWriter(qw422016)
 //line test.qtpl:75
 }
 
 //line test.qtpl:75
 func Foo(a []FooArgs) string {
-	//line test.qtpl:75
+//line test.qtpl:75
 	qb422016 := qt422016.AcquireByteBuffer()
-	//line test.qtpl:75
+//line test.qtpl:75
 	WriteFoo(qb422016, a)
-	//line test.qtpl:75
+//line test.qtpl:75
 	qs422016 := string(qb422016.B)
-	//line test.qtpl:75
+//line test.qtpl:75
 	qt422016.ReleaseByteBuffer(qb422016)
-	//line test.qtpl:75
+//line test.qtpl:75
 	return qs422016
 //line test.qtpl:75
 }
@@ -465,113 +465,113 @@ func Foo(a []FooArgs) string {
 
 //line test.qtpl:80
 func streamprintArgs(qw422016 *qt422016.Writer, i int, a *FooArgs) {
-	//line test.qtpl:80
+//line test.qtpl:80
 	qw422016.N().S(`
 	`)
-	//line test.qtpl:81
+//line test.qtpl:81
 	if i == 0 {
-		//line test.qtpl:81
+//line test.qtpl:81
 		qw422016.N().S(`
 		Hide args for i = 0
 		`)
-		//line test.qtpl:83
+//line test.qtpl:83
 		return
-		//line test.qtpl:87
+//line test.qtpl:87
 	}
-	//line test.qtpl:87
+//line test.qtpl:87
 	qw422016.N().S(`
 	<li>
 		a[`)
-	//line test.qtpl:89
+//line test.qtpl:89
 	qw422016.N().D(i)
-	//line test.qtpl:89
+//line test.qtpl:89
 	qw422016.N().S(`] = {S: `)
-	//line test.qtpl:89
+//line test.qtpl:89
 	qw422016.E().Q(a.S)
-	//line test.qtpl:89
+//line test.qtpl:89
 	qw422016.N().S(`, SS: `)
-	//line test.qtpl:89
+//line test.qtpl:89
 	qw422016.E().QZ([]byte(a.S))
-	//line test.qtpl:89
+//line test.qtpl:89
 	qw422016.N().S(`, N: `)
-	//line test.qtpl:89
+//line test.qtpl:89
 	qw422016.N().D(a.N)
-	//line test.qtpl:89
+//line test.qtpl:89
 	qw422016.N().S(`}<br>
 		`)
-	//line test.qtpl:90
+//line test.qtpl:90
 	qw422016.E().S(a.S)
-	//line test.qtpl:90
+//line test.qtpl:90
 	qw422016.N().S(`, `)
-	//line test.qtpl:90
+//line test.qtpl:90
 	qw422016.E().Z([]byte(a.S))
-	//line test.qtpl:90
+//line test.qtpl:90
 	qw422016.N().S(`, `)
-	//line test.qtpl:90
+//line test.qtpl:90
 	qw422016.E().SZ([]byte(a.S))
-	//line test.qtpl:90
+//line test.qtpl:90
 	qw422016.N().S(`
 		`)
-	//line test.qtpl:91
+//line test.qtpl:91
 	qw422016.N().F(1.234)
-	//line test.qtpl:91
+//line test.qtpl:91
 	qw422016.N().S(`, `)
-	//line test.qtpl:91
+//line test.qtpl:91
 	qw422016.N().FPrec(1.234, 1)
-	//line test.qtpl:91
+//line test.qtpl:91
 	qw422016.N().S(`, `)
-	//line test.qtpl:91
+//line test.qtpl:91
 	qw422016.N().FPrec(1.234, 2)
-	//line test.qtpl:91
+//line test.qtpl:91
 	qw422016.N().S(`
 		alert("foo `)
-	//line test.qtpl:92
+//line test.qtpl:92
 	qw422016.E().J("bar\naaa")
-	//line test.qtpl:92
+//line test.qtpl:92
 	qw422016.N().S(` baz `)
-	//line test.qtpl:92
+//line test.qtpl:92
 	qw422016.E().JZ([]byte("aaa"))
-	//line test.qtpl:92
+//line test.qtpl:92
 	qw422016.N().S(`")<br/>
 		<a href="?`)
-	//line test.qtpl:93
+//line test.qtpl:93
 	qw422016.N().U("аргумент 1")
-	//line test.qtpl:93
+//line test.qtpl:93
 	qw422016.N().S(`=`)
-	//line test.qtpl:93
+//line test.qtpl:93
 	qw422016.N().U("значение=<>\"'&1")
-	//line test.qtpl:93
+//line test.qtpl:93
 	qw422016.N().S(`">test1</a>
 		<a href="?`)
-	//line test.qtpl:94
+//line test.qtpl:94
 	qw422016.N().UZ([]byte("foobar"))
-	//line test.qtpl:94
+//line test.qtpl:94
 	qw422016.N().S(`=123">test2</a>
 	</li>
 
 	Switch statement:
 	`)
-	//line test.qtpl:98
+//line test.qtpl:98
 	qw422016.N().S(`a.S =`)
-	//line test.qtpl:100
+//line test.qtpl:100
 	switch a.S {
-	//line test.qtpl:101
+//line test.qtpl:101
 	case "foo":
-		//line test.qtpl:101
+//line test.qtpl:101
 		qw422016.N().S(`foo`)
-		//line test.qtpl:103
+//line test.qtpl:103
 		break
-	//line test.qtpl:105
+//line test.qtpl:105
 	case "bar":
-		//line test.qtpl:105
+//line test.qtpl:105
 		qw422016.N().S(`bar`)
-	//line test.qtpl:107
+//line test.qtpl:107
 	default:
-		//line test.qtpl:108
+//line test.qtpl:108
 		qw422016.E().Q(a.S)
-		//line test.qtpl:109
+//line test.qtpl:109
 	}
-	//line test.qtpl:110
+//line test.qtpl:110
 	qw422016.N().S(`
 `)
 //line test.qtpl:111
@@ -579,26 +579,26 @@ func streamprintArgs(qw422016 *qt422016.Writer, i int, a *FooArgs) {
 
 //line test.qtpl:111
 func writeprintArgs(qq422016 qtio422016.Writer, i int, a *FooArgs) {
-	//line test.qtpl:111
+//line test.qtpl:111
 	qw422016 := qt422016.AcquireWriter(qq422016)
-	//line test.qtpl:111
+//line test.qtpl:111
 	streamprintArgs(qw422016, i, a)
-	//line test.qtpl:111
+//line test.qtpl:111
 	qt422016.ReleaseWriter(qw422016)
 //line test.qtpl:111
 }
 
 //line test.qtpl:111
 func printArgs(i int, a *FooArgs) string {
-	//line test.qtpl:111
+//line test.qtpl:111
 	qb422016 := qt422016.AcquireByteBuffer()
-	//line test.qtpl:111
+//line test.qtpl:111
 	writeprintArgs(qb422016, i, a)
-	//line test.qtpl:111
+//line test.qtpl:111
 	qs422016 := string(qb422016.B)
-	//line test.qtpl:111
+//line test.qtpl:111
 	qt422016.ReleaseByteBuffer(qb422016)
-	//line test.qtpl:111
+//line test.qtpl:111
 	return qs422016
 //line test.qtpl:111
 }
@@ -607,17 +607,17 @@ func printArgs(i int, a *FooArgs) string {
 
 //line test.qtpl:115
 type Page interface {
-	//line test.qtpl:115
+//line test.qtpl:115
 	Head() string
-	//line test.qtpl:115
+//line test.qtpl:115
 	StreamHead(qw422016 *qt422016.Writer)
-	//line test.qtpl:115
+//line test.qtpl:115
 	WriteHead(qq422016 qtio422016.Writer)
-	//line test.qtpl:115
+//line test.qtpl:115
 	Body(title string) string
-	//line test.qtpl:115
+//line test.qtpl:115
 	StreamBody(qw422016 *qt422016.Writer, title string)
-	//line test.qtpl:115
+//line test.qtpl:115
 	WriteBody(qq422016 qtio422016.Writer, title string)
 //line test.qtpl:115
 }
@@ -626,18 +626,18 @@ type Page interface {
 
 //line test.qtpl:125
 func StreamPrintPage(qw422016 *qt422016.Writer, p Page, title string) {
-	//line test.qtpl:125
+//line test.qtpl:125
 	qw422016.N().S(`
 	<html>
 		<head>`)
-	//line test.qtpl:127
+//line test.qtpl:127
 	p.StreamHead(qw422016)
-	//line test.qtpl:127
+//line test.qtpl:127
 	qw422016.N().S(`</head>
 		<body>`)
-	//line test.qtpl:128
+//line test.qtpl:128
 	p.StreamBody(qw422016, title)
-	//line test.qtpl:128
+//line test.qtpl:128
 	qw422016.N().S(`</body>
 	</html>
 `)
@@ -646,26 +646,26 @@ func StreamPrintPage(qw422016 *qt422016.Writer, p Page, title string) {
 
 //line test.qtpl:130
 func WritePrintPage(qq422016 qtio422016.Writer, p Page, title string) {
-	//line test.qtpl:130
+//line test.qtpl:130
 	qw422016 := qt422016.AcquireWriter(qq422016)
-	//line test.qtpl:130
+//line test.qtpl:130
 	StreamPrintPage(qw422016, p, title)
-	//line test.qtpl:130
+//line test.qtpl:130
 	qt422016.ReleaseWriter(qw422016)
 //line test.qtpl:130
 }
 
 //line test.qtpl:130
 func PrintPage(p Page, title string) string {
-	//line test.qtpl:130
+//line test.qtpl:130
 	qb422016 := qt422016.AcquireByteBuffer()
-	//line test.qtpl:130
+//line test.qtpl:130
 	WritePrintPage(qb422016, p, title)
-	//line test.qtpl:130
+//line test.qtpl:130
 	qs422016 := string(qb422016.B)
-	//line test.qtpl:130
+//line test.qtpl:130
 	qt422016.ReleaseByteBuffer(qb422016)
-	//line test.qtpl:130
+//line test.qtpl:130
 	return qs422016
 //line test.qtpl:130
 }
@@ -677,66 +677,66 @@ type ContactsPage struct{}
 
 //line test.qtpl:134
 func (b *ContactsPage) StreamHead(qw422016 *qt422016.Writer) {
-	//line test.qtpl:134
+//line test.qtpl:134
 	qw422016.N().S(`<title>Contacts!</title>`)
 //line test.qtpl:134
 }
 
 //line test.qtpl:134
 func (b *ContactsPage) WriteHead(qq422016 qtio422016.Writer) {
-	//line test.qtpl:134
+//line test.qtpl:134
 	qw422016 := qt422016.AcquireWriter(qq422016)
-	//line test.qtpl:134
+//line test.qtpl:134
 	b.StreamHead(qw422016)
-	//line test.qtpl:134
+//line test.qtpl:134
 	qt422016.ReleaseWriter(qw422016)
 //line test.qtpl:134
 }
 
 //line test.qtpl:134
 func (b *ContactsPage) Head() string {
-	//line test.qtpl:134
+//line test.qtpl:134
 	qb422016 := qt422016.AcquireByteBuffer()
-	//line test.qtpl:134
+//line test.qtpl:134
 	b.WriteHead(qb422016)
-	//line test.qtpl:134
+//line test.qtpl:134
 	qs422016 := string(qb422016.B)
-	//line test.qtpl:134
+//line test.qtpl:134
 	qt422016.ReleaseByteBuffer(qb422016)
-	//line test.qtpl:134
+//line test.qtpl:134
 	return qs422016
 //line test.qtpl:134
 }
 
 //line test.qtpl:135
 func (b *ContactsPage) StreamBody(qw422016 *qt422016.Writer, title string) {
-	//line test.qtpl:135
+//line test.qtpl:135
 	qw422016.N().S(`Put here contact info`)
 //line test.qtpl:135
 }
 
 //line test.qtpl:135
 func (b *ContactsPage) WriteBody(qq422016 qtio422016.Writer, title string) {
-	//line test.qtpl:135
+//line test.qtpl:135
 	qw422016 := qt422016.AcquireWriter(qq422016)
-	//line test.qtpl:135
+//line test.qtpl:135
 	b.StreamBody(qw422016, title)
-	//line test.qtpl:135
+//line test.qtpl:135
 	qt422016.ReleaseWriter(qw422016)
 //line test.qtpl:135
 }
 
 //line test.qtpl:135
 func (b *ContactsPage) Body(title string) string {
-	//line test.qtpl:135
+//line test.qtpl:135
 	qb422016 := qt422016.AcquireByteBuffer()
-	//line test.qtpl:135
+//line test.qtpl:135
 	b.WriteBody(qb422016, title)
-	//line test.qtpl:135
+//line test.qtpl:135
 	qs422016 := string(qb422016.B)
-	//line test.qtpl:135
+//line test.qtpl:135
 	qt422016.ReleaseByteBuffer(qb422016)
-	//line test.qtpl:135
+//line test.qtpl:135
 	return qs422016
 //line test.qtpl:135
 }
@@ -748,45 +748,45 @@ type Homepage struct{}
 
 //line test.qtpl:139
 func (h *Homepage) StreamHead(qw422016 *qt422016.Writer) {
-	//line test.qtpl:139
+//line test.qtpl:139
 	qw422016.N().S(`<title>Homepage</title>`)
 //line test.qtpl:139
 }
 
 //line test.qtpl:139
 func (h *Homepage) WriteHead(qq422016 qtio422016.Writer) {
-	//line test.qtpl:139
+//line test.qtpl:139
 	qw422016 := qt422016.AcquireWriter(qq422016)
-	//line test.qtpl:139
+//line test.qtpl:139
 	h.StreamHead(qw422016)
-	//line test.qtpl:139
+//line test.qtpl:139
 	qt422016.ReleaseWriter(qw422016)
 //line test.qtpl:139
 }
 
 //line test.qtpl:139
 func (h *Homepage) Head() string {
-	//line test.qtpl:139
+//line test.qtpl:139
 	qb422016 := qt422016.AcquireByteBuffer()
-	//line test.qtpl:139
+//line test.qtpl:139
 	h.WriteHead(qb422016)
-	//line test.qtpl:139
+//line test.qtpl:139
 	qs422016 := string(qb422016.B)
-	//line test.qtpl:139
+//line test.qtpl:139
 	qt422016.ReleaseByteBuffer(qb422016)
-	//line test.qtpl:139
+//line test.qtpl:139
 	return qs422016
 //line test.qtpl:139
 }
 
 //line test.qtpl:140
 func (h *Homepage) StreamBody(qw422016 *qt422016.Writer, title string) {
-	//line test.qtpl:140
+//line test.qtpl:140
 	qw422016.N().S(`
 	Title: `)
-	//line test.qtpl:141
+//line test.qtpl:141
 	qw422016.N().S(title)
-	//line test.qtpl:141
+//line test.qtpl:141
 	qw422016.N().S(`
 	Homepage body
 `)
@@ -795,26 +795,26 @@ func (h *Homepage) StreamBody(qw422016 *qt422016.Writer, title string) {
 
 //line test.qtpl:143
 func (h *Homepage) WriteBody(qq422016 qtio422016.Writer, title string) {
-	//line test.qtpl:143
+//line test.qtpl:143
 	qw422016 := qt422016.AcquireWriter(qq422016)
-	//line test.qtpl:143
+//line test.qtpl:143
 	h.StreamBody(qw422016, title)
-	//line test.qtpl:143
+//line test.qtpl:143
 	qt422016.ReleaseWriter(qw422016)
 //line test.qtpl:143
 }
 
 //line test.qtpl:143
 func (h *Homepage) Body(title string) string {
-	//line test.qtpl:143
+//line test.qtpl:143
 	qb422016 := qt422016.AcquireByteBuffer()
-	//line test.qtpl:143
+//line test.qtpl:143
 	h.WriteBody(qb422016, title)
-	//line test.qtpl:143
+//line test.qtpl:143
 	qs422016 := string(qb422016.B)
-	//line test.qtpl:143
+//line test.qtpl:143
 	qt422016.ReleaseByteBuffer(qb422016)
-	//line test.qtpl:143
+//line test.qtpl:143
 	return qs422016
 //line test.qtpl:143
 }
@@ -825,31 +825,31 @@ func (h *Homepage) Body(title string) string {
 
 //line test.qtpl:153
 func StreamVariadic(qw422016 *qt422016.Writer, a int, b ...string) {
-	//line test.qtpl:153
+//line test.qtpl:153
 	qw422016.N().S(`
 	a = `)
-	//line test.qtpl:154
+//line test.qtpl:154
 	qw422016.N().D(a)
-	//line test.qtpl:154
+//line test.qtpl:154
 	qw422016.N().S(`
 	`)
-	//line test.qtpl:155
+//line test.qtpl:155
 	for i, s := range b {
-		//line test.qtpl:155
+//line test.qtpl:155
 		qw422016.N().S(`
 		`)
-		//line test.qtpl:156
+//line test.qtpl:156
 		qw422016.N().D(i)
-		//line test.qtpl:156
+//line test.qtpl:156
 		qw422016.N().S(`: `)
-		//line test.qtpl:156
+//line test.qtpl:156
 		qw422016.E().S(s)
-		//line test.qtpl:156
+//line test.qtpl:156
 		qw422016.N().S(`
 	`)
-		//line test.qtpl:157
+//line test.qtpl:157
 	}
-	//line test.qtpl:157
+//line test.qtpl:157
 	qw422016.N().S(`
 `)
 //line test.qtpl:158
@@ -857,26 +857,26 @@ func StreamVariadic(qw422016 *qt422016.Writer, a int, b ...string) {
 
 //line test.qtpl:158
 func WriteVariadic(qq422016 qtio422016.Writer, a int, b ...string) {
-	//line test.qtpl:158
+//line test.qtpl:158
 	qw422016 := qt422016.AcquireWriter(qq422016)
-	//line test.qtpl:158
+//line test.qtpl:158
 	StreamVariadic(qw422016, a, b...)
-	//line test.qtpl:158
+//line test.qtpl:158
 	qt422016.ReleaseWriter(qw422016)
 //line test.qtpl:158
 }
 
 //line test.qtpl:158
 func Variadic(a int, b ...string) string {
-	//line test.qtpl:158
+//line test.qtpl:158
 	qb422016 := qt422016.AcquireByteBuffer()
-	//line test.qtpl:158
+//line test.qtpl:158
 	WriteVariadic(qb422016, a, b...)
-	//line test.qtpl:158
+//line test.qtpl:158
 	qs422016 := string(qb422016.B)
-	//line test.qtpl:158
+//line test.qtpl:158
 	qt422016.ReleaseByteBuffer(qb422016)
-	//line test.qtpl:158
+//line test.qtpl:158
 	return qs422016
 //line test.qtpl:158
 }

--- a/testdata/templates/bench.qtpl.go
+++ b/testdata/templates/bench.qtpl.go
@@ -26,39 +26,39 @@ type BenchRow struct {
 
 //line testdata/templates/bench.qtpl:11
 func StreamBenchPage(qw422016 *qt422016.Writer, rows []BenchRow) {
-	//line testdata/templates/bench.qtpl:11
+//line testdata/templates/bench.qtpl:11
 	qw422016.N().S(`<html>
 	<head><title>test</title></head>
 	<body>
 		<ul>
 		`)
-	//line testdata/templates/bench.qtpl:15
+//line testdata/templates/bench.qtpl:15
 	for _, row := range rows {
-		//line testdata/templates/bench.qtpl:15
+//line testdata/templates/bench.qtpl:15
 		qw422016.N().S(`
 			`)
-		//line testdata/templates/bench.qtpl:16
+//line testdata/templates/bench.qtpl:16
 		if row.Print {
-			//line testdata/templates/bench.qtpl:16
+//line testdata/templates/bench.qtpl:16
 			qw422016.N().S(`
 				<li>ID=`)
-			//line testdata/templates/bench.qtpl:17
+//line testdata/templates/bench.qtpl:17
 			qw422016.N().D(row.ID)
-			//line testdata/templates/bench.qtpl:17
+//line testdata/templates/bench.qtpl:17
 			qw422016.N().S(`, Message=`)
-			//line testdata/templates/bench.qtpl:17
+//line testdata/templates/bench.qtpl:17
 			qw422016.E().S(row.Message)
-			//line testdata/templates/bench.qtpl:17
+//line testdata/templates/bench.qtpl:17
 			qw422016.N().S(`</li>
 			`)
-			//line testdata/templates/bench.qtpl:18
+//line testdata/templates/bench.qtpl:18
 		}
-		//line testdata/templates/bench.qtpl:18
+//line testdata/templates/bench.qtpl:18
 		qw422016.N().S(`
 		`)
-		//line testdata/templates/bench.qtpl:19
+//line testdata/templates/bench.qtpl:19
 	}
-	//line testdata/templates/bench.qtpl:19
+//line testdata/templates/bench.qtpl:19
 	qw422016.N().S(`
 		</ul>
 	</body>
@@ -69,26 +69,26 @@ func StreamBenchPage(qw422016 *qt422016.Writer, rows []BenchRow) {
 
 //line testdata/templates/bench.qtpl:23
 func WriteBenchPage(qq422016 qtio422016.Writer, rows []BenchRow) {
-	//line testdata/templates/bench.qtpl:23
+//line testdata/templates/bench.qtpl:23
 	qw422016 := qt422016.AcquireWriter(qq422016)
-	//line testdata/templates/bench.qtpl:23
+//line testdata/templates/bench.qtpl:23
 	StreamBenchPage(qw422016, rows)
-	//line testdata/templates/bench.qtpl:23
+//line testdata/templates/bench.qtpl:23
 	qt422016.ReleaseWriter(qw422016)
 //line testdata/templates/bench.qtpl:23
 }
 
 //line testdata/templates/bench.qtpl:23
 func BenchPage(rows []BenchRow) string {
-	//line testdata/templates/bench.qtpl:23
+//line testdata/templates/bench.qtpl:23
 	qb422016 := qt422016.AcquireByteBuffer()
-	//line testdata/templates/bench.qtpl:23
+//line testdata/templates/bench.qtpl:23
 	WriteBenchPage(qb422016, rows)
-	//line testdata/templates/bench.qtpl:23
+//line testdata/templates/bench.qtpl:23
 	qs422016 := string(qb422016.B)
-	//line testdata/templates/bench.qtpl:23
+//line testdata/templates/bench.qtpl:23
 	qt422016.ReleaseByteBuffer(qb422016)
-	//line testdata/templates/bench.qtpl:23
+//line testdata/templates/bench.qtpl:23
 	return qs422016
 //line testdata/templates/bench.qtpl:23
 }

--- a/testdata/templates/integration.qtpl.go
+++ b/testdata/templates/integration.qtpl.go
@@ -26,349 +26,349 @@ var (
 
 //line testdata/templates/integration.qtpl:6
 func StreamIntegration(qw422016 *qt422016.Writer) {
-	//line testdata/templates/integration.qtpl:6
+//line testdata/templates/integration.qtpl:6
 	qw422016.N().S(`
 	Output tags`)
-	//line testdata/templates/integration.qtpl:6
+//line testdata/templates/integration.qtpl:6
 	qw422016.N().S("`")
-	//line testdata/templates/integration.qtpl:6
+//line testdata/templates/integration.qtpl:6
 	qw422016.N().S(` verification.
 
 	`)
-	//line testdata/templates/integration.qtpl:10
+//line testdata/templates/integration.qtpl:10
 	p := &integrationPage{
 		S: "foobar",
 	}
 
-	//line testdata/templates/integration.qtpl:13
+//line testdata/templates/integration.qtpl:13
 	qw422016.N().S(`
 	Embedded func template:
 		plain: `)
-	//line testdata/templates/integration.qtpl:15
+//line testdata/templates/integration.qtpl:15
 	streamembeddedFunc(qw422016, p)
-	//line testdata/templates/integration.qtpl:15
+//line testdata/templates/integration.qtpl:15
 	qw422016.N().S(`
 		html-escaped: `)
-	//line testdata/templates/integration.qtpl:16
+//line testdata/templates/integration.qtpl:16
 	{
-		//line testdata/templates/integration.qtpl:16
+//line testdata/templates/integration.qtpl:16
 		qb422016 := qt422016.AcquireByteBuffer()
-		//line testdata/templates/integration.qtpl:16
+//line testdata/templates/integration.qtpl:16
 		writeembeddedFunc(qb422016, p)
-		//line testdata/templates/integration.qtpl:16
+//line testdata/templates/integration.qtpl:16
 		qw422016.E().Z(qb422016.B)
-		//line testdata/templates/integration.qtpl:16
+//line testdata/templates/integration.qtpl:16
 		qt422016.ReleaseByteBuffer(qb422016)
-		//line testdata/templates/integration.qtpl:16
+//line testdata/templates/integration.qtpl:16
 	}
-	//line testdata/templates/integration.qtpl:16
+//line testdata/templates/integration.qtpl:16
 	qw422016.N().S(`
 		url-escaped: `)
-	//line testdata/templates/integration.qtpl:17
+//line testdata/templates/integration.qtpl:17
 	{
-		//line testdata/templates/integration.qtpl:17
+//line testdata/templates/integration.qtpl:17
 		qb422016 := qt422016.AcquireByteBuffer()
-		//line testdata/templates/integration.qtpl:17
+//line testdata/templates/integration.qtpl:17
 		writeembeddedFunc(qb422016, p)
-		//line testdata/templates/integration.qtpl:17
+//line testdata/templates/integration.qtpl:17
 		qw422016.N().UZ(qb422016.B)
-		//line testdata/templates/integration.qtpl:17
+//line testdata/templates/integration.qtpl:17
 		qt422016.ReleaseByteBuffer(qb422016)
-		//line testdata/templates/integration.qtpl:17
+//line testdata/templates/integration.qtpl:17
 	}
-	//line testdata/templates/integration.qtpl:17
+//line testdata/templates/integration.qtpl:17
 	qw422016.N().S(`
 		quoted json string: `)
-	//line testdata/templates/integration.qtpl:18
+//line testdata/templates/integration.qtpl:18
 	{
-		//line testdata/templates/integration.qtpl:18
+//line testdata/templates/integration.qtpl:18
 		qb422016 := qt422016.AcquireByteBuffer()
-		//line testdata/templates/integration.qtpl:18
+//line testdata/templates/integration.qtpl:18
 		writeembeddedFunc(qb422016, p)
-		//line testdata/templates/integration.qtpl:18
+//line testdata/templates/integration.qtpl:18
 		qw422016.N().QZ(qb422016.B)
-		//line testdata/templates/integration.qtpl:18
+//line testdata/templates/integration.qtpl:18
 		qt422016.ReleaseByteBuffer(qb422016)
-		//line testdata/templates/integration.qtpl:18
+//line testdata/templates/integration.qtpl:18
 	}
-	//line testdata/templates/integration.qtpl:18
+//line testdata/templates/integration.qtpl:18
 	qw422016.N().S(`
 		unquoted json string: `)
-	//line testdata/templates/integration.qtpl:19
+//line testdata/templates/integration.qtpl:19
 	{
-		//line testdata/templates/integration.qtpl:19
+//line testdata/templates/integration.qtpl:19
 		qb422016 := qt422016.AcquireByteBuffer()
-		//line testdata/templates/integration.qtpl:19
+//line testdata/templates/integration.qtpl:19
 		writeembeddedFunc(qb422016, p)
-		//line testdata/templates/integration.qtpl:19
+//line testdata/templates/integration.qtpl:19
 		qw422016.N().JZ(qb422016.B)
-		//line testdata/templates/integration.qtpl:19
+//line testdata/templates/integration.qtpl:19
 		qt422016.ReleaseByteBuffer(qb422016)
-		//line testdata/templates/integration.qtpl:19
+//line testdata/templates/integration.qtpl:19
 	}
-	//line testdata/templates/integration.qtpl:19
+//line testdata/templates/integration.qtpl:19
 	qw422016.N().S(`
 		html-escaped url-escaped: `)
-	//line testdata/templates/integration.qtpl:20
+//line testdata/templates/integration.qtpl:20
 	{
-		//line testdata/templates/integration.qtpl:20
+//line testdata/templates/integration.qtpl:20
 		qb422016 := qt422016.AcquireByteBuffer()
-		//line testdata/templates/integration.qtpl:20
+//line testdata/templates/integration.qtpl:20
 		writeembeddedFunc(qb422016, p)
-		//line testdata/templates/integration.qtpl:20
+//line testdata/templates/integration.qtpl:20
 		qw422016.N().UZ(qb422016.B)
-		//line testdata/templates/integration.qtpl:20
+//line testdata/templates/integration.qtpl:20
 		qt422016.ReleaseByteBuffer(qb422016)
-		//line testdata/templates/integration.qtpl:20
+//line testdata/templates/integration.qtpl:20
 	}
-	//line testdata/templates/integration.qtpl:20
+//line testdata/templates/integration.qtpl:20
 	qw422016.N().S(`
 		html-escaped quoted json string: `)
-	//line testdata/templates/integration.qtpl:21
+//line testdata/templates/integration.qtpl:21
 	{
-		//line testdata/templates/integration.qtpl:21
+//line testdata/templates/integration.qtpl:21
 		qb422016 := qt422016.AcquireByteBuffer()
-		//line testdata/templates/integration.qtpl:21
+//line testdata/templates/integration.qtpl:21
 		writeembeddedFunc(qb422016, p)
-		//line testdata/templates/integration.qtpl:21
+//line testdata/templates/integration.qtpl:21
 		qw422016.E().QZ(qb422016.B)
-		//line testdata/templates/integration.qtpl:21
+//line testdata/templates/integration.qtpl:21
 		qt422016.ReleaseByteBuffer(qb422016)
-		//line testdata/templates/integration.qtpl:21
+//line testdata/templates/integration.qtpl:21
 	}
-	//line testdata/templates/integration.qtpl:21
+//line testdata/templates/integration.qtpl:21
 	qw422016.N().S(`
 		html-escaped unquoted json string: `)
-	//line testdata/templates/integration.qtpl:22
+//line testdata/templates/integration.qtpl:22
 	{
-		//line testdata/templates/integration.qtpl:22
+//line testdata/templates/integration.qtpl:22
 		qb422016 := qt422016.AcquireByteBuffer()
-		//line testdata/templates/integration.qtpl:22
+//line testdata/templates/integration.qtpl:22
 		writeembeddedFunc(qb422016, p)
-		//line testdata/templates/integration.qtpl:22
+//line testdata/templates/integration.qtpl:22
 		qw422016.E().JZ(qb422016.B)
-		//line testdata/templates/integration.qtpl:22
+//line testdata/templates/integration.qtpl:22
 		qt422016.ReleaseByteBuffer(qb422016)
-		//line testdata/templates/integration.qtpl:22
+//line testdata/templates/integration.qtpl:22
 	}
-	//line testdata/templates/integration.qtpl:22
+//line testdata/templates/integration.qtpl:22
 	qw422016.N().S(`
 
 	Html-escaped output tags:
 	<ul>
 		<li>`)
-	//line testdata/templates/integration.qtpl:26
+//line testdata/templates/integration.qtpl:26
 	qw422016.E().S("<b>html-escaped `string</b>")
-	//line testdata/templates/integration.qtpl:26
+//line testdata/templates/integration.qtpl:26
 	qw422016.N().S(`</li>
 		<li>`)
-	//line testdata/templates/integration.qtpl:27
+//line testdata/templates/integration.qtpl:27
 	qw422016.E().Z([]byte("<b>html-escaped `byte slice</b>"))
-	//line testdata/templates/integration.qtpl:27
+//line testdata/templates/integration.qtpl:27
 	qw422016.N().S(`</li>
 		<li>Int: `)
-	//line testdata/templates/integration.qtpl:28
+//line testdata/templates/integration.qtpl:28
 	qw422016.N().D(42)
-	//line testdata/templates/integration.qtpl:28
+//line testdata/templates/integration.qtpl:28
 	qw422016.N().S(`</li>
 		<li>Float: `)
-	//line testdata/templates/integration.qtpl:29
+//line testdata/templates/integration.qtpl:29
 	qw422016.N().F(3.14)
-	//line testdata/templates/integration.qtpl:29
+//line testdata/templates/integration.qtpl:29
 	qw422016.N().S(`</li>
 		<li>`)
-	//line testdata/templates/integration.qtpl:30
+//line testdata/templates/integration.qtpl:30
 	qw422016.E().Q(`<quoted> "json"
 				string`)
-	//line testdata/templates/integration.qtpl:31
+//line testdata/templates/integration.qtpl:31
 	qw422016.N().S(`</li>
 		<li>alert("foo `)
-	//line testdata/templates/integration.qtpl:32
+//line testdata/templates/integration.qtpl:32
 	qw422016.E().J(`"json"-safe
 				<string>`)
-	//line testdata/templates/integration.qtpl:33
+//line testdata/templates/integration.qtpl:33
 	qw422016.N().S(` aa" + 'bar `)
-	//line testdata/templates/integration.qtpl:33
+//line testdata/templates/integration.qtpl:33
 	qw422016.E().J(`';alert("evil")</script>`)
-	//line testdata/templates/integration.qtpl:33
+//line testdata/templates/integration.qtpl:33
 	qw422016.N().S(`')</li>
 		<li><a href="?`)
-	//line testdata/templates/integration.qtpl:34
+//line testdata/templates/integration.qtpl:34
 	qw422016.N().U("ключ")
-	//line testdata/templates/integration.qtpl:34
+//line testdata/templates/integration.qtpl:34
 	qw422016.N().S(`=`)
-	//line testdata/templates/integration.qtpl:34
+//line testdata/templates/integration.qtpl:34
 	qw422016.N().U("значение&=?123")
-	//line testdata/templates/integration.qtpl:34
+//line testdata/templates/integration.qtpl:34
 	qw422016.N().S(`">test</a></li>
 		<li>`)
-	//line testdata/templates/integration.qtpl:35
+//line testdata/templates/integration.qtpl:35
 	qw422016.E().V(struct{ A string }{A: "<b>foobar`</b>"})
-	//line testdata/templates/integration.qtpl:35
+//line testdata/templates/integration.qtpl:35
 	qw422016.N().S(`</li>
 	</ul>
 
 	Output tags without html escaping
 	<ul>
 		<li>`)
-	//line testdata/templates/integration.qtpl:40
+//line testdata/templates/integration.qtpl:40
 	qw422016.N().S("<b>html-escaped `string</b>")
-	//line testdata/templates/integration.qtpl:40
+//line testdata/templates/integration.qtpl:40
 	qw422016.N().S(`</li>
 		<li>`)
-	//line testdata/templates/integration.qtpl:41
+//line testdata/templates/integration.qtpl:41
 	qw422016.N().Z([]byte("<b>html-escaped `byte slice</b>"))
-	//line testdata/templates/integration.qtpl:41
+//line testdata/templates/integration.qtpl:41
 	qw422016.N().S(`</li>
 		<li>Int: `)
-	//line testdata/templates/integration.qtpl:42
+//line testdata/templates/integration.qtpl:42
 	qw422016.N().D(42)
-	//line testdata/templates/integration.qtpl:42
+//line testdata/templates/integration.qtpl:42
 	qw422016.N().S(`</li>
 		<li>Float: `)
-	//line testdata/templates/integration.qtpl:43
+//line testdata/templates/integration.qtpl:43
 	qw422016.N().F(3.14)
-	//line testdata/templates/integration.qtpl:43
+//line testdata/templates/integration.qtpl:43
 	qw422016.N().S(`</li>
 		<li>`)
-	//line testdata/templates/integration.qtpl:44
+//line testdata/templates/integration.qtpl:44
 	qw422016.N().Q(`<quoted> "json"
 				string`)
-	//line testdata/templates/integration.qtpl:45
+//line testdata/templates/integration.qtpl:45
 	qw422016.N().S(`</li>
 		<li>alert("foo `)
-	//line testdata/templates/integration.qtpl:46
+//line testdata/templates/integration.qtpl:46
 	qw422016.N().J(`"json"-safe
 				<string>`)
-	//line testdata/templates/integration.qtpl:47
+//line testdata/templates/integration.qtpl:47
 	qw422016.N().S(` aa" + 'bar `)
-	//line testdata/templates/integration.qtpl:47
+//line testdata/templates/integration.qtpl:47
 	qw422016.N().J(`';alert("evil")</script>`)
-	//line testdata/templates/integration.qtpl:47
+//line testdata/templates/integration.qtpl:47
 	qw422016.N().S(`')</li>
 		<li><a href="?`)
-	//line testdata/templates/integration.qtpl:48
+//line testdata/templates/integration.qtpl:48
 	qw422016.N().U("ключ")
-	//line testdata/templates/integration.qtpl:48
+//line testdata/templates/integration.qtpl:48
 	qw422016.N().S(`=`)
-	//line testdata/templates/integration.qtpl:48
+//line testdata/templates/integration.qtpl:48
 	qw422016.N().U("значение&=?123")
-	//line testdata/templates/integration.qtpl:48
+//line testdata/templates/integration.qtpl:48
 	qw422016.N().S(`">test</a></li>
 		<li>`)
-	//line testdata/templates/integration.qtpl:49
+//line testdata/templates/integration.qtpl:49
 	qw422016.N().V(struct{ A string }{A: "<b>foobar`</b>"})
-	//line testdata/templates/integration.qtpl:49
+//line testdata/templates/integration.qtpl:49
 	qw422016.N().S(`</li>
 	</ul>
 
 	`)
-	//line testdata/templates/integration.qtpl:52
+//line testdata/templates/integration.qtpl:52
 	qw422016.N().S(`Strip space`)
-	//line testdata/templates/integration.qtpl:53
+//line testdata/templates/integration.qtpl:53
 	qw422016.N().S(` `)
-	//line testdata/templates/integration.qtpl:53
+//line testdata/templates/integration.qtpl:53
 	qw422016.N().S(`between lines and tags`)
-	//line testdata/templates/integration.qtpl:55
+//line testdata/templates/integration.qtpl:55
 	qw422016.N().S(`
 			Tags aren't parsed {%inside %}
 			plain
 		`)
-	//line testdata/templates/integration.qtpl:59
+//line testdata/templates/integration.qtpl:59
 	// one-liner comment
 
-	//line testdata/templates/integration.qtpl:61
+//line testdata/templates/integration.qtpl:61
 	// multi-line
 	// comment
 
-	//line testdata/templates/integration.qtpl:65
+//line testdata/templates/integration.qtpl:65
 	/*
 	  yet another
 	  multi-line comment
 	*/
 
-	//line testdata/templates/integration.qtpl:70
+//line testdata/templates/integration.qtpl:70
 	qw422016.N().S(`
 
 	`)
-	//line testdata/templates/integration.qtpl:72
+//line testdata/templates/integration.qtpl:72
 	qw422016.N().S(` Collapse space `)
-	//line testdata/templates/integration.qtpl:73
+//line testdata/templates/integration.qtpl:73
 	qw422016.N().S(` `)
-	//line testdata/templates/integration.qtpl:73
+//line testdata/templates/integration.qtpl:73
 	qw422016.N().S(` between `)
-	//line testdata/templates/integration.qtpl:74
+//line testdata/templates/integration.qtpl:74
 	qw422016.N().S(`
 `)
-	//line testdata/templates/integration.qtpl:74
+//line testdata/templates/integration.qtpl:74
 	qw422016.N().S(` lines and tags `)
-	//line testdata/templates/integration.qtpl:78
+//line testdata/templates/integration.qtpl:78
 	qw422016.N().S(` `)
-	//line testdata/templates/integration.qtpl:80
+//line testdata/templates/integration.qtpl:80
 	for _, s := range []string{"foo", "bar", "baz"} {
-		//line testdata/templates/integration.qtpl:80
+//line testdata/templates/integration.qtpl:80
 		qw422016.N().S(` `)
-		//line testdata/templates/integration.qtpl:81
+//line testdata/templates/integration.qtpl:81
 		if s == "bar" {
-			//line testdata/templates/integration.qtpl:81
+//line testdata/templates/integration.qtpl:81
 			qw422016.N().S(` Bar `)
-			//line testdata/templates/integration.qtpl:83
+//line testdata/templates/integration.qtpl:83
 		} else if s == "baz" {
-			//line testdata/templates/integration.qtpl:83
+//line testdata/templates/integration.qtpl:83
 			qw422016.N().S(` Baz `)
-			//line testdata/templates/integration.qtpl:85
+//line testdata/templates/integration.qtpl:85
 			break
-			//line testdata/templates/integration.qtpl:86
+//line testdata/templates/integration.qtpl:86
 		} else {
-			//line testdata/templates/integration.qtpl:86
+//line testdata/templates/integration.qtpl:86
 			qw422016.N().S(` `)
-			//line testdata/templates/integration.qtpl:87
+//line testdata/templates/integration.qtpl:87
 			if s == "never" {
-				//line testdata/templates/integration.qtpl:87
+//line testdata/templates/integration.qtpl:87
 				qw422016.N().S(` `)
-				//line testdata/templates/integration.qtpl:88
+//line testdata/templates/integration.qtpl:88
 				return
-				//line testdata/templates/integration.qtpl:89
+//line testdata/templates/integration.qtpl:89
 			}
-			//line testdata/templates/integration.qtpl:89
+//line testdata/templates/integration.qtpl:89
 			qw422016.N().S(` `)
-			//line testdata/templates/integration.qtpl:91
+//line testdata/templates/integration.qtpl:91
 			switch s {
-			//line testdata/templates/integration.qtpl:92
+//line testdata/templates/integration.qtpl:92
 			case "foobar":
-				//line testdata/templates/integration.qtpl:92
+//line testdata/templates/integration.qtpl:92
 				qw422016.N().S(` s = foobar `)
-			//line testdata/templates/integration.qtpl:94
+//line testdata/templates/integration.qtpl:94
 			case "barbaz":
-				//line testdata/templates/integration.qtpl:94
+//line testdata/templates/integration.qtpl:94
 				qw422016.N().S(` s = barbaz `)
-			//line testdata/templates/integration.qtpl:96
+//line testdata/templates/integration.qtpl:96
 			default:
-				//line testdata/templates/integration.qtpl:96
+//line testdata/templates/integration.qtpl:96
 				qw422016.N().S(` s = `)
-				//line testdata/templates/integration.qtpl:97
+//line testdata/templates/integration.qtpl:97
 				qw422016.E().S(s)
-				//line testdata/templates/integration.qtpl:97
+//line testdata/templates/integration.qtpl:97
 				qw422016.N().S(` `)
-				//line testdata/templates/integration.qtpl:98
+//line testdata/templates/integration.qtpl:98
 			}
-			//line testdata/templates/integration.qtpl:98
+//line testdata/templates/integration.qtpl:98
 			qw422016.N().S(` `)
-			//line testdata/templates/integration.qtpl:100
+//line testdata/templates/integration.qtpl:100
 			continue
-			//line testdata/templates/integration.qtpl:101
+//line testdata/templates/integration.qtpl:101
 		}
-		//line testdata/templates/integration.qtpl:101
+//line testdata/templates/integration.qtpl:101
 		qw422016.N().S(` `)
-		//line testdata/templates/integration.qtpl:102
+//line testdata/templates/integration.qtpl:102
 	}
-	//line testdata/templates/integration.qtpl:102
+//line testdata/templates/integration.qtpl:102
 	qw422016.N().S(` `)
-	//line testdata/templates/integration.qtpl:103
+//line testdata/templates/integration.qtpl:103
 	qw422016.N().S(`
 
 	`)
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S(`This is a template for integration test.
 It should contains all the quicktemplate stuff.
 
@@ -376,9 +376,9 @@ It should contains all the quicktemplate stuff.
 
 {% func Integration() %}
 	Output tags`)
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S("`")
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S(` verification.
 
 	{% code
@@ -399,100 +399,100 @@ It should contains all the quicktemplate stuff.
 	Html-escaped output tags:
 	<ul>
 		<li>{%s "<b>html-escaped `)
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S("`")
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S(`string</b>" %}</li>
 		<li>{%z []byte("<b>html-escaped `)
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S("`")
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S(`byte slice</b>") %}</li>
 		<li>Int: {%d 42 %}</li>
 		<li>Float: {%f 3.14 %}</li>
 		<li>{%q `)
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S("`")
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S(`<quoted> "json"
 				string`)
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S("`")
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S(` %}</li>
 		<li>alert("foo {%j `)
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S("`")
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S(`"json"-safe
 				<string>`)
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S("`")
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S(` %} aa" + 'bar {%j `)
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S("`")
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S(`';alert("evil")</script>`)
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S("`")
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S(` %}')</li>
 		<li><a href="?{%u "ключ" %}={%u "значение&=?123" %}">test</a></li>
 		<li>{%v struct{ A string }{A: "<b>foobar`)
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S("`")
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S(`</b>"} %}</li>
 	</ul>
 
 	Output tags without html escaping
 	<ul>
 		<li>{%s= "<b>html-escaped `)
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S("`")
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S(`string</b>" %}</li>
 		<li>{%z= []byte("<b>html-escaped `)
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S("`")
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S(`byte slice</b>") %}</li>
 		<li>Int: {%d= 42 %}</li>
 		<li>Float: {%f= 3.14 %}</li>
 		<li>{%q= `)
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S("`")
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S(`<quoted> "json"
 				string`)
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S("`")
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S(` %}</li>
 		<li>alert("foo {%j= `)
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S("`")
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S(`"json"-safe
 				<string>`)
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S("`")
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S(` %} aa" + 'bar {%j= `)
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S("`")
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S(`';alert("evil")</script>`)
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S("`")
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S(` %}')</li>
 		<li><a href="?{%u= "ключ" %}={%u= "значение&=?123" %}">test</a></li>
 		<li>{%v= struct{ A string }{A: "<b>foobar`)
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S("`")
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S(`</b>"} %}</li>
 	</ul>
 
@@ -578,7 +578,7 @@ type integrationPage struct {
 	S={%q p.S %}
 {% endfunc %}
 `)
-	//line testdata/templates/integration.qtpl:105
+//line testdata/templates/integration.qtpl:105
 	qw422016.N().S(`
 
 	tail of the func
@@ -588,60 +588,60 @@ type integrationPage struct {
 
 //line testdata/templates/integration.qtpl:108
 func WriteIntegration(qq422016 qtio422016.Writer) {
-	//line testdata/templates/integration.qtpl:108
+//line testdata/templates/integration.qtpl:108
 	qw422016 := qt422016.AcquireWriter(qq422016)
-	//line testdata/templates/integration.qtpl:108
+//line testdata/templates/integration.qtpl:108
 	StreamIntegration(qw422016)
-	//line testdata/templates/integration.qtpl:108
+//line testdata/templates/integration.qtpl:108
 	qt422016.ReleaseWriter(qw422016)
 //line testdata/templates/integration.qtpl:108
 }
 
 //line testdata/templates/integration.qtpl:108
 func Integration() string {
-	//line testdata/templates/integration.qtpl:108
+//line testdata/templates/integration.qtpl:108
 	qb422016 := qt422016.AcquireByteBuffer()
-	//line testdata/templates/integration.qtpl:108
+//line testdata/templates/integration.qtpl:108
 	WriteIntegration(qb422016)
-	//line testdata/templates/integration.qtpl:108
+//line testdata/templates/integration.qtpl:108
 	qs422016 := string(qb422016.B)
-	//line testdata/templates/integration.qtpl:108
+//line testdata/templates/integration.qtpl:108
 	qt422016.ReleaseByteBuffer(qb422016)
-	//line testdata/templates/integration.qtpl:108
+//line testdata/templates/integration.qtpl:108
 	return qs422016
 //line testdata/templates/integration.qtpl:108
 }
 
 //line testdata/templates/integration.qtpl:111
 type Page interface {
-	//line testdata/templates/integration.qtpl:111
+//line testdata/templates/integration.qtpl:111
 	Header() string
-	//line testdata/templates/integration.qtpl:111
+//line testdata/templates/integration.qtpl:111
 	StreamHeader(qw422016 *qt422016.Writer)
-	//line testdata/templates/integration.qtpl:111
+//line testdata/templates/integration.qtpl:111
 	WriteHeader(qq422016 qtio422016.Writer)
-	//line testdata/templates/integration.qtpl:111
+//line testdata/templates/integration.qtpl:111
 	Body() string
-	//line testdata/templates/integration.qtpl:111
+//line testdata/templates/integration.qtpl:111
 	StreamBody(qw422016 *qt422016.Writer)
-	//line testdata/templates/integration.qtpl:111
+//line testdata/templates/integration.qtpl:111
 	WriteBody(qq422016 qtio422016.Writer)
 //line testdata/templates/integration.qtpl:111
 }
 
 //line testdata/templates/integration.qtpl:117
 func streamembeddedFunc(qw422016 *qt422016.Writer, p Page) {
-	//line testdata/templates/integration.qtpl:117
+//line testdata/templates/integration.qtpl:117
 	qw422016.N().S(`
 	Page's header: `)
-	//line testdata/templates/integration.qtpl:118
+//line testdata/templates/integration.qtpl:118
 	p.StreamHeader(qw422016)
-	//line testdata/templates/integration.qtpl:118
+//line testdata/templates/integration.qtpl:118
 	qw422016.N().S(`
 	Body: `)
-	//line testdata/templates/integration.qtpl:119
+//line testdata/templates/integration.qtpl:119
 	qw422016.N().S(fmt.Sprintf("<b>%s</b>", p.Body()))
-	//line testdata/templates/integration.qtpl:119
+//line testdata/templates/integration.qtpl:119
 	qw422016.N().S(`
 `)
 //line testdata/templates/integration.qtpl:120
@@ -649,26 +649,26 @@ func streamembeddedFunc(qw422016 *qt422016.Writer, p Page) {
 
 //line testdata/templates/integration.qtpl:120
 func writeembeddedFunc(qq422016 qtio422016.Writer, p Page) {
-	//line testdata/templates/integration.qtpl:120
+//line testdata/templates/integration.qtpl:120
 	qw422016 := qt422016.AcquireWriter(qq422016)
-	//line testdata/templates/integration.qtpl:120
+//line testdata/templates/integration.qtpl:120
 	streamembeddedFunc(qw422016, p)
-	//line testdata/templates/integration.qtpl:120
+//line testdata/templates/integration.qtpl:120
 	qt422016.ReleaseWriter(qw422016)
 //line testdata/templates/integration.qtpl:120
 }
 
 //line testdata/templates/integration.qtpl:120
 func embeddedFunc(p Page) string {
-	//line testdata/templates/integration.qtpl:120
+//line testdata/templates/integration.qtpl:120
 	qb422016 := qt422016.AcquireByteBuffer()
-	//line testdata/templates/integration.qtpl:120
+//line testdata/templates/integration.qtpl:120
 	writeembeddedFunc(qb422016, p)
-	//line testdata/templates/integration.qtpl:120
+//line testdata/templates/integration.qtpl:120
 	qs422016 := string(qb422016.B)
-	//line testdata/templates/integration.qtpl:120
+//line testdata/templates/integration.qtpl:120
 	qt422016.ReleaseByteBuffer(qb422016)
-	//line testdata/templates/integration.qtpl:120
+//line testdata/templates/integration.qtpl:120
 	return qs422016
 //line testdata/templates/integration.qtpl:120
 }
@@ -680,45 +680,45 @@ type integrationPage struct {
 
 //line testdata/templates/integration.qtpl:128
 func (p *integrationPage) StreamHeader(qw422016 *qt422016.Writer) {
-	//line testdata/templates/integration.qtpl:128
+//line testdata/templates/integration.qtpl:128
 	qw422016.N().S(`Header`)
 //line testdata/templates/integration.qtpl:128
 }
 
 //line testdata/templates/integration.qtpl:128
 func (p *integrationPage) WriteHeader(qq422016 qtio422016.Writer) {
-	//line testdata/templates/integration.qtpl:128
+//line testdata/templates/integration.qtpl:128
 	qw422016 := qt422016.AcquireWriter(qq422016)
-	//line testdata/templates/integration.qtpl:128
+//line testdata/templates/integration.qtpl:128
 	p.StreamHeader(qw422016)
-	//line testdata/templates/integration.qtpl:128
+//line testdata/templates/integration.qtpl:128
 	qt422016.ReleaseWriter(qw422016)
 //line testdata/templates/integration.qtpl:128
 }
 
 //line testdata/templates/integration.qtpl:128
 func (p *integrationPage) Header() string {
-	//line testdata/templates/integration.qtpl:128
+//line testdata/templates/integration.qtpl:128
 	qb422016 := qt422016.AcquireByteBuffer()
-	//line testdata/templates/integration.qtpl:128
+//line testdata/templates/integration.qtpl:128
 	p.WriteHeader(qb422016)
-	//line testdata/templates/integration.qtpl:128
+//line testdata/templates/integration.qtpl:128
 	qs422016 := string(qb422016.B)
-	//line testdata/templates/integration.qtpl:128
+//line testdata/templates/integration.qtpl:128
 	qt422016.ReleaseByteBuffer(qb422016)
-	//line testdata/templates/integration.qtpl:128
+//line testdata/templates/integration.qtpl:128
 	return qs422016
 //line testdata/templates/integration.qtpl:128
 }
 
 //line testdata/templates/integration.qtpl:130
 func (p *integrationPage) StreamBody(qw422016 *qt422016.Writer) {
-	//line testdata/templates/integration.qtpl:130
+//line testdata/templates/integration.qtpl:130
 	qw422016.N().S(`
 	S=`)
-	//line testdata/templates/integration.qtpl:131
+//line testdata/templates/integration.qtpl:131
 	qw422016.E().Q(p.S)
-	//line testdata/templates/integration.qtpl:131
+//line testdata/templates/integration.qtpl:131
 	qw422016.N().S(`
 `)
 //line testdata/templates/integration.qtpl:132
@@ -726,26 +726,26 @@ func (p *integrationPage) StreamBody(qw422016 *qt422016.Writer) {
 
 //line testdata/templates/integration.qtpl:132
 func (p *integrationPage) WriteBody(qq422016 qtio422016.Writer) {
-	//line testdata/templates/integration.qtpl:132
+//line testdata/templates/integration.qtpl:132
 	qw422016 := qt422016.AcquireWriter(qq422016)
-	//line testdata/templates/integration.qtpl:132
+//line testdata/templates/integration.qtpl:132
 	p.StreamBody(qw422016)
-	//line testdata/templates/integration.qtpl:132
+//line testdata/templates/integration.qtpl:132
 	qt422016.ReleaseWriter(qw422016)
 //line testdata/templates/integration.qtpl:132
 }
 
 //line testdata/templates/integration.qtpl:132
 func (p *integrationPage) Body() string {
-	//line testdata/templates/integration.qtpl:132
+//line testdata/templates/integration.qtpl:132
 	qb422016 := qt422016.AcquireByteBuffer()
-	//line testdata/templates/integration.qtpl:132
+//line testdata/templates/integration.qtpl:132
 	p.WriteBody(qb422016)
-	//line testdata/templates/integration.qtpl:132
+//line testdata/templates/integration.qtpl:132
 	qs422016 := string(qb422016.B)
-	//line testdata/templates/integration.qtpl:132
+//line testdata/templates/integration.qtpl:132
 	qt422016.ReleaseByteBuffer(qb422016)
-	//line testdata/templates/integration.qtpl:132
+//line testdata/templates/integration.qtpl:132
 	return qs422016
 //line testdata/templates/integration.qtpl:132
 }

--- a/testdata/templates/marshal.qtpl.go
+++ b/testdata/templates/marshal.qtpl.go
@@ -36,63 +36,63 @@ type MarshalData struct {
 
 //line testdata/templates/marshal.qtpl:18
 func (d *MarshalData) StreamJSON(qw422016 *qt422016.Writer) {
-	//line testdata/templates/marshal.qtpl:18
+//line testdata/templates/marshal.qtpl:18
 	qw422016.N().S(`{"Foo":`)
-	//line testdata/templates/marshal.qtpl:20
+//line testdata/templates/marshal.qtpl:20
 	qw422016.N().D(d.Foo)
-	//line testdata/templates/marshal.qtpl:20
+//line testdata/templates/marshal.qtpl:20
 	qw422016.N().S(`,"Bar":`)
-	//line testdata/templates/marshal.qtpl:21
+//line testdata/templates/marshal.qtpl:21
 	qw422016.N().Q(d.Bar)
-	//line testdata/templates/marshal.qtpl:21
+//line testdata/templates/marshal.qtpl:21
 	qw422016.N().S(`,"Rows":[`)
-	//line testdata/templates/marshal.qtpl:23
+//line testdata/templates/marshal.qtpl:23
 	for i, r := range d.Rows {
-		//line testdata/templates/marshal.qtpl:23
+//line testdata/templates/marshal.qtpl:23
 		qw422016.N().S(`{"Msg":`)
-		//line testdata/templates/marshal.qtpl:25
+//line testdata/templates/marshal.qtpl:25
 		qw422016.N().Q(r.Msg)
-		//line testdata/templates/marshal.qtpl:25
+//line testdata/templates/marshal.qtpl:25
 		qw422016.N().S(`,"N":`)
-		//line testdata/templates/marshal.qtpl:26
+//line testdata/templates/marshal.qtpl:26
 		qw422016.N().D(r.N)
-		//line testdata/templates/marshal.qtpl:26
+//line testdata/templates/marshal.qtpl:26
 		qw422016.N().S(`}`)
-		//line testdata/templates/marshal.qtpl:28
+//line testdata/templates/marshal.qtpl:28
 		if i+1 < len(d.Rows) {
-			//line testdata/templates/marshal.qtpl:28
+//line testdata/templates/marshal.qtpl:28
 			qw422016.N().S(`,`)
-			//line testdata/templates/marshal.qtpl:28
+//line testdata/templates/marshal.qtpl:28
 		}
-		//line testdata/templates/marshal.qtpl:29
+//line testdata/templates/marshal.qtpl:29
 	}
-	//line testdata/templates/marshal.qtpl:29
+//line testdata/templates/marshal.qtpl:29
 	qw422016.N().S(`]}`)
 //line testdata/templates/marshal.qtpl:32
 }
 
 //line testdata/templates/marshal.qtpl:32
 func (d *MarshalData) WriteJSON(qq422016 qtio422016.Writer) {
-	//line testdata/templates/marshal.qtpl:32
+//line testdata/templates/marshal.qtpl:32
 	qw422016 := qt422016.AcquireWriter(qq422016)
-	//line testdata/templates/marshal.qtpl:32
+//line testdata/templates/marshal.qtpl:32
 	d.StreamJSON(qw422016)
-	//line testdata/templates/marshal.qtpl:32
+//line testdata/templates/marshal.qtpl:32
 	qt422016.ReleaseWriter(qw422016)
 //line testdata/templates/marshal.qtpl:32
 }
 
 //line testdata/templates/marshal.qtpl:32
 func (d *MarshalData) JSON() string {
-	//line testdata/templates/marshal.qtpl:32
+//line testdata/templates/marshal.qtpl:32
 	qb422016 := qt422016.AcquireByteBuffer()
-	//line testdata/templates/marshal.qtpl:32
+//line testdata/templates/marshal.qtpl:32
 	d.WriteJSON(qb422016)
-	//line testdata/templates/marshal.qtpl:32
+//line testdata/templates/marshal.qtpl:32
 	qs422016 := string(qb422016.B)
-	//line testdata/templates/marshal.qtpl:32
+//line testdata/templates/marshal.qtpl:32
 	qt422016.ReleaseByteBuffer(qb422016)
-	//line testdata/templates/marshal.qtpl:32
+//line testdata/templates/marshal.qtpl:32
 	return qs422016
 //line testdata/templates/marshal.qtpl:32
 }
@@ -101,57 +101,57 @@ func (d *MarshalData) JSON() string {
 
 //line testdata/templates/marshal.qtpl:37
 func (d *MarshalData) StreamXML(qw422016 *qt422016.Writer) {
-	//line testdata/templates/marshal.qtpl:37
+//line testdata/templates/marshal.qtpl:37
 	qw422016.N().S(`<MarshalData><Foo>`)
-	//line testdata/templates/marshal.qtpl:39
+//line testdata/templates/marshal.qtpl:39
 	qw422016.N().D(d.Foo)
-	//line testdata/templates/marshal.qtpl:39
+//line testdata/templates/marshal.qtpl:39
 	qw422016.N().S(`</Foo><Bar>`)
-	//line testdata/templates/marshal.qtpl:40
+//line testdata/templates/marshal.qtpl:40
 	qw422016.E().S(d.Bar)
-	//line testdata/templates/marshal.qtpl:40
+//line testdata/templates/marshal.qtpl:40
 	qw422016.N().S(`</Bar>`)
-	//line testdata/templates/marshal.qtpl:41
+//line testdata/templates/marshal.qtpl:41
 	for _, r := range d.Rows {
-		//line testdata/templates/marshal.qtpl:41
+//line testdata/templates/marshal.qtpl:41
 		qw422016.N().S(`<Rows><Msg>`)
-		//line testdata/templates/marshal.qtpl:43
+//line testdata/templates/marshal.qtpl:43
 		qw422016.E().S(r.Msg)
-		//line testdata/templates/marshal.qtpl:43
+//line testdata/templates/marshal.qtpl:43
 		qw422016.N().S(`</Msg><N>`)
-		//line testdata/templates/marshal.qtpl:44
+//line testdata/templates/marshal.qtpl:44
 		qw422016.N().D(r.N)
-		//line testdata/templates/marshal.qtpl:44
+//line testdata/templates/marshal.qtpl:44
 		qw422016.N().S(`</N></Rows>`)
-		//line testdata/templates/marshal.qtpl:46
+//line testdata/templates/marshal.qtpl:46
 	}
-	//line testdata/templates/marshal.qtpl:46
+//line testdata/templates/marshal.qtpl:46
 	qw422016.N().S(`</MarshalData>`)
 //line testdata/templates/marshal.qtpl:48
 }
 
 //line testdata/templates/marshal.qtpl:48
 func (d *MarshalData) WriteXML(qq422016 qtio422016.Writer) {
-	//line testdata/templates/marshal.qtpl:48
+//line testdata/templates/marshal.qtpl:48
 	qw422016 := qt422016.AcquireWriter(qq422016)
-	//line testdata/templates/marshal.qtpl:48
+//line testdata/templates/marshal.qtpl:48
 	d.StreamXML(qw422016)
-	//line testdata/templates/marshal.qtpl:48
+//line testdata/templates/marshal.qtpl:48
 	qt422016.ReleaseWriter(qw422016)
 //line testdata/templates/marshal.qtpl:48
 }
 
 //line testdata/templates/marshal.qtpl:48
 func (d *MarshalData) XML() string {
-	//line testdata/templates/marshal.qtpl:48
+//line testdata/templates/marshal.qtpl:48
 	qb422016 := qt422016.AcquireByteBuffer()
-	//line testdata/templates/marshal.qtpl:48
+//line testdata/templates/marshal.qtpl:48
 	d.WriteXML(qb422016)
-	//line testdata/templates/marshal.qtpl:48
+//line testdata/templates/marshal.qtpl:48
 	qs422016 := string(qb422016.B)
-	//line testdata/templates/marshal.qtpl:48
+//line testdata/templates/marshal.qtpl:48
 	qt422016.ReleaseByteBuffer(qb422016)
-	//line testdata/templates/marshal.qtpl:48
+//line testdata/templates/marshal.qtpl:48
 	return qs422016
 //line testdata/templates/marshal.qtpl:48
 }


### PR DESCRIPTION
Go doesn't support `//line` comments with leading whitespace. Without this change line numbers will be incorrect in errors generated by the Go compiler and runtime.

I, Daniel Parks, disclaim all rights to this code.