### PR TITLE
add tag modifier strip blank before and after tag

### DIFF
--- a/parser/scanner.go
+++ b/parser/scanner.go
@@ -284,6 +284,8 @@ func (s *scanner) readText() bool {
 		s.unreadByte('{')
 		s.appendByte()
 	}
+	s.stripPrevBlank = false
+	s.stripToNewLine = false
 	if s.nextByte() {
 		if s.c == '-' {
 			s.stripPrevBlank = true

--- a/parser/scanner.go
+++ b/parser/scanner.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 )
 
@@ -67,8 +68,13 @@ type scanner struct {
 
 	collapseSpaceDepth int
 	stripSpaceDepth    int
+	stripToNewLine     bool
+	stripPrevBlank     bool
 	rewind             bool
 }
+
+var tailOfLine = regexp.MustCompile("^[[:blank:]]*\r?\n")
+var prevBlank = regexp.MustCompile("[[:blank:]]*$")
 
 func newScanner(r io.Reader, filePath string) *scanner {
 	// Substitute backslashes with forward slashes in filePath
@@ -104,6 +110,14 @@ func (s *scanner) Next() bool {
 			if len(s.t.Value) == 0 {
 				// skip empty text
 				continue
+			}
+			if s.stripPrevBlank {
+				s.t.Value = prevBlank.ReplaceAll(s.t.Value, []byte{})
+				s.stripPrevBlank = false
+			}
+			if s.stripToNewLine {
+				s.t.Value = tailOfLine.ReplaceAll(s.t.Value, []byte{})
+				s.stripToNewLine = false
 			}
 		case tagName:
 			switch string(s.t.Value) {
@@ -270,6 +284,13 @@ func (s *scanner) readText() bool {
 		s.unreadByte('{')
 		s.appendByte()
 	}
+	if s.nextByte() {
+		if s.c == '-' {
+			s.stripPrevBlank = true
+		} else {
+			s.unreadByte(s.c)
+		}
+	}
 	if s.stripSpaceDepth > 0 {
 		s.t.Value = stripSpace(s.t.Value)
 	} else if s.collapseSpaceDepth > 0 {
@@ -282,8 +303,8 @@ func (s *scanner) readTagName() bool {
 	s.skipSpace()
 	s.t.init(tagName, s.line, s.pos())
 	for {
-		if s.isSpace() || s.c == '%' {
-			if s.c == '%' {
+		if s.isSpace() || s.c == '%' || s.c == '-' {
+			if s.c == '%' || s.c == '-' {
 				s.unreadByte('~')
 			}
 			s.nextTokenID = tagContents
@@ -306,21 +327,44 @@ func (s *scanner) readTagContents() bool {
 	s.skipSpace()
 	s.t.init(tagContents, s.line, s.pos())
 	for {
-		if s.c != '%' {
+		var minus bool
+		if s.c != '-' && s.c != '%' {
 			s.appendByte()
 			if !s.nextByte() {
 				return false
 			}
 			continue
 		}
+		if s.c == '-' {
+			minus = true
+			if !s.nextByte() {
+				s.appendByte()
+				return false
+			}
+
+			if s.c != '%' {
+				s.unreadByte('-')
+				s.appendByte()
+				if !s.nextByte() {
+					return false
+				}
+				continue
+			}
+		}
 		if !s.nextByte() {
 			s.appendByte()
 			return false
 		}
 		if s.c == '}' {
+			if minus {
+				s.stripToNewLine = true
+			}
 			s.nextTokenID = text
 			s.t.Value = stripTrailingSpace(s.t.Value)
 			return true
+		}
+		if minus {
+			s.t.Value = append(s.t.Value, '-')
 		}
 		s.unreadByte('%')
 		s.appendByte()

--- a/parser/scanner_test.go
+++ b/parser/scanner_test.go
@@ -50,6 +50,16 @@ func TestScannerEndTagWithMinus(t *testing.T) {
 			{ID: tagName, Value: "bar"},
 			{ID: tagContents, Value: "-"},
 		})
+	testScannerSuccess(t, "{%foo-%}{%bar%} \n {%baz%}",
+		[]tt{
+			{ID: tagName, Value: "foo"},
+			{ID: tagContents, Value: ""},
+			{ID: tagName, Value: "bar"},
+			{ID: tagContents, Value: ""},
+			{ID: text, Value: " \n "},
+			{ID: tagName, Value: "baz"},
+			{ID: tagContents, Value: ""},
+		})
 }
 
 func TestScannerBeginTagWithMinus(t *testing.T) {
@@ -84,6 +94,16 @@ func TestScannerBeginTagWithMinus(t *testing.T) {
 			{ID: text, Value: " awer {-"},
 			{ID: tagName, Value: "aa="},
 			{ID: tagContents, Value: "xxx"},
+		})
+	testScannerSuccess(t, "{%-foo%}{%bar%} \n {%baz%}",
+		[]tt{
+			{ID: tagName, Value: "foo"},
+			{ID: tagContents, Value: ""},
+			{ID: tagName, Value: "bar"},
+			{ID: tagContents, Value: ""},
+			{ID: text, Value: " \n "},
+			{ID: tagName, Value: "baz"},
+			{ID: tagContents, Value: ""},
 		})
 }
 


### PR DESCRIPTION
My Proposal for issue#63

Tag opening mark "{%-" strip tail blanks form previous text.
Tag ending mark  "-%}" strip blanks to new line from next text.
Below code

```
{% func GenTestFunc() %}
func TestFunc(a int, b int) int {
	var sum int
	{%- for i := 0; i < 10; i++ -%}
	sum += {%d i %}
	{%- endfor %}
	return sum
}
{% endfunc %}
```

outputs

```
func TestFunc(a int, b int) int {
	var sum int
	sum += 0
	sum += 1
	sum += 2
	sum += 3
	sum += 4
	sum += 5
	sum += 6
	sum += 7
	sum += 8
	sum += 9

	return sum
}
```