### PR TITLE
Add skipLineComments flag

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -13,14 +13,14 @@ import (
 )
 
 type parser struct {
-	s               *scanner
-	w               io.Writer
-	packageName     string
-	lineComments    bool
-	prefix          string
-	forDepth        int
-	switchDepth     int
-	skipOutputDepth int
+	s                *scanner
+	w                io.Writer
+	packageName      string
+	skipLineComments bool
+	prefix           string
+	forDepth         int
+	switchDepth      int
+	skipOutputDepth  int
 
 	importsUseEmitted  bool
 	packageNameEmitted bool
@@ -30,20 +30,20 @@ type parser struct {
 // the supplied writer. Uses filename as the source file for line comments, and
 // pkg as the Go package name.
 func Parse(w io.Writer, r io.Reader, filename, pkg string) error {
-	return parse(w, r, filename, pkg, true)
+	return parse(w, r, filename, pkg, false)
 }
 
 // ParseNoLineComments is the same as Parse, but does not write line comments.
 func ParseNoLineComments(w io.Writer, r io.Reader, filename, pkg string) error {
-	return parse(w, r, filename, pkg, false)
+	return parse(w, r, filename, pkg, true)
 }
 
-func parse(w io.Writer, r io.Reader, filename, pkg string, lineComments bool) error {
+func parse(w io.Writer, r io.Reader, filename, pkg string, skipLineComments bool) error {
 	p := &parser{
-		s:            newScanner(r, filename),
-		w:            w,
-		packageName:  pkg,
-		lineComments: lineComments,
+		s:                newScanner(r, filename),
+		w:                w,
+		packageName:      pkg,
+		skipLineComments: skipLineComments,
 	}
 	return p.parseTemplate()
 }
@@ -812,7 +812,7 @@ func (p *parser) Printf(format string, args ...interface{}) {
 		return
 	}
 	w := p.w
-	if p.lineComments {
+	if !p.skipLineComments {
 		// line comments are required to start at the beginning of the line
 		p.s.WriteLineComment(w)
 	}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -606,3 +606,15 @@ func TestParseFile(t *testing.T) {
 		t.Fatalf("unexpected code:\n%q\nexpected:\n%q", code, expectedCode)
 	}
 }
+
+func TestParseNoLineComments(t *testing.T) {
+	const str = "foobar\nbaz"
+	r := bytes.NewBufferString(str)
+	w := &bytes.Buffer{}
+	if err := ParseNoLineComments(w, r, "qtc-test.qtpl", "memory"); err != nil {
+		t.Fatalf("unexpected error when parsing %q: %s", str, err)
+	}
+	if bytes.Contains(w.Bytes(), []byte("//line")) {
+		t.Fatal("unexpected line comment")
+	}
+}

--- a/qtc/main.go
+++ b/qtc/main.go
@@ -25,7 +25,8 @@ var (
 	file = flag.String("file", "", "Path to template file to compile.\n"+
 		"Flags -dir and -ext are ignored if file is set.\n"+
 		"The compiled file will be placed near the original file with .go extension added.")
-	ext = flag.String("ext", "qtpl", "Only files with this extension are compiled")
+	ext              = flag.String("ext", "qtpl", "Only files with this extension are compiled")
+	skipLineComments = flag.Bool("skipLineComments", false, "Don't write line comments")
 )
 
 var logger = log.New(os.Stderr, "qtc: ", log.LstdFlags)
@@ -127,9 +128,16 @@ func compileFile(infile string) {
 	if err != nil {
 		logger.Fatalf("cannot determine package name for %q: %s", infile, err)
 	}
-	if err = parser.Parse(outf, inf, infile, packageName); err != nil {
+
+	parseFunc := parser.Parse
+	if *skipLineComments {
+		parseFunc = parser.ParseNoLineComments
+	}
+
+	if err = parseFunc(outf, inf, infile, packageName); err != nil {
 		logger.Fatalf("error when parsing file %q: %s", infile, err)
 	}
+
 	if err = outf.Close(); err != nil {
 		logger.Fatalf("error when closing file %q: %s", tmpfile, err)
 	}


### PR DESCRIPTION
Fixes #67.

To not change the `parse` package's API and break potential importers, I added another function variant.

~I haven't yet written tests; I'd likely just duplicate TestParseFile. Will do it when I have a bit more time, but this is functional as-is (and I'm now using it in one of my projects).~

Happy to take feedback.