### PR TITLE
add all int type, delete unused variable, use TrimSuffix instead of HasSuffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ The `{%s x %}` is used for printing HTML-safe strings, while `{%= F() %}`
 is used for embedding template function calls. Quicktemplate supports also
 other output tags:
 
-  * `{%d int %}` and `{%dl int64 %}` `{%dul uint64 %}` for integers.
+  * `{%d int %}` and `{%dl int64 %}` `{%dul uint64 %}` `{%dl32 int32 %}` `{%dul32 uint32 %}` etc. for integers.
   * `{%f float %}` for float64.
     Floating point precision may be set via `{%f.precision float %}`.
     For example, `{%f.2 1.2345 %}` outputs `1.23`.

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -489,8 +489,8 @@ func (p *parser) parseIf() error {
 func (p *parser) tryParseCommonTags(tagBytes []byte) (bool, error) {
 	tagNameStr, prec := splitTagNamePrec(string(tagBytes))
 	switch tagNameStr {
-	case "s", "v", "d", "dl", "dul", "f", "q", "z", "j", "u",
-		"s=", "v=", "d=", "dl=", "dul=", "f=", "q=", "z=", "j=", "u=",
+	case "s", "v", "d", "dl", "dl32", "dl16", "dl8", "dul", "dul32", "dul16", "dul8", "f", "q", "z", "j", "u",
+		"s=", "v=", "d=", "dl=", "dl32=", "dl16=", "dl8=", "dul=", "dul31=", "dul16=", "dul8=", "f=", "q=", "z=", "j=", "u=",
 		"sz", "qz", "jz", "uz",
 		"sz=", "qz=", "jz=", "uz=":
 		if err := p.parseOutputTag(tagNameStr, prec); err != nil {
@@ -548,9 +548,7 @@ func splitTagNamePrec(tagName string) (string, int) {
 	parts := strings.Split(tagName, ".")
 	if len(parts) == 2 && parts[0] == "f" {
 		p := parts[1]
-		if strings.HasSuffix(p, "=") {
-			p = p[:len(p)-1]
-		}
+		p = strings.TrimSuffix(p, "=")
 		if len(p) == 0 {
 			return "f", 0
 		}
@@ -719,9 +717,7 @@ func (p *parser) parseOutputTag(tagNameStr string, prec int) error {
 	case "s", "v", "q", "z", "j", "sz", "qz", "jz":
 		filter = "E"
 	}
-	if strings.HasSuffix(tagNameStr, "=") {
-		tagNameStr = tagNameStr[:len(tagNameStr)-1]
-	}
+	tagNameStr = strings.TrimSuffix(tagNameStr, "=")
 	if tagNameStr == "f" && prec >= 0 {
 		p.Printf("qw%s.N().FPrec(%s, %d)", mangleSuffix, t.Value, prec)
 	} else {

--- a/testdata/qtc/test.qtpl
+++ b/testdata/qtc/test.qtpl
@@ -86,7 +86,7 @@ Now define private printArgs, which is called in Foo via {%= %} tag
 		{% for %}And this: {% break %} {% return %}{% endfor %}
 	{% endif %}
 	<li>
-		a[{%d i %}] = {S: {%q a.S %}, SS: {%qz []byte(a.S) %}, N: {%dl int64(a.N) %}, NN: {%dul uint64(a.N) %}}<br>
+		a[{%d i %}] = {S: {%q a.S %}, SS: {%qz []byte(a.S) %}, N: {%dl int64(a.N) %}, N32: {%dl32 int32(a.N) %}, NN: {%dul uint64(a.N) %}, NN32: {%dul32 uint32(a.N) %}}<br>
 		{%s a.S %}, {%z []byte(a.S) %}, {%sz []byte(a.S) %}
 		{%f 1.234 %}, {%f.1 1.234 %}, {% f.2= 1.234 %}
 		alert("foo {%j "bar\naaa" %} baz {%jz []byte("aaa") %}")<br/>

--- a/testdata/qtc/test.qtpl.expected
+++ b/testdata/qtc/test.qtpl.expected
@@ -358,7 +358,7 @@ Now define private printArgs, which is called in Foo via {%= %} tag
 		{% for %}And this: {% break %} {% return %}{% endfor %}
 	{% endif %}
 	<li>
-		a[{%d i %}] = {S: {%q a.S %}, SS: {%qz []byte(a.S) %}, N: {%dl int64(a.N) %}, NN: {%dul uint64(a.N) %}}<br>
+		a[{%d i %}] = {S: {%q a.S %}, SS: {%qz []byte(a.S) %}, N: {%dl int64(a.N) %}, N32: {%dl32 int32(a.N) %}, NN: {%dul uint64(a.N) %}, NN32: {%dul32 uint32(a.N) %}}<br>
 		{%s a.S %}, {%z []byte(a.S) %}, {%sz []byte(a.S) %}
 		{%f 1.234 %}, {%f.1 1.234 %}, {% f.2= 1.234 %}
 		alert("foo {%j "bar\naaa" %} baz {%jz []byte("aaa") %}")<br/>

--- a/writer.go
+++ b/writer.go
@@ -125,6 +125,39 @@ func (w *QWriter) DL(n int64) {
 	}
 }
 
+// DL32 writes n to w
+func (w *QWriter) DL32(n int32) {
+	bb, ok := w.w.(*ByteBuffer)
+	if ok {
+		bb.B = strconv.AppendInt(bb.B, int64(n), 10)
+	} else {
+		w.b = strconv.AppendInt(w.b[:0], int64(n), 10)
+		w.Write(w.b)
+	}
+}
+
+// DL16 writes n to w
+func (w *QWriter) DL16(n int16) {
+	bb, ok := w.w.(*ByteBuffer)
+	if ok {
+		bb.B = strconv.AppendInt(bb.B, int64(n), 10)
+	} else {
+		w.b = strconv.AppendInt(w.b[:0], int64(n), 10)
+		w.Write(w.b)
+	}
+}
+
+// DL8 writes n to w
+func (w *QWriter) DL8(n int8) {
+	bb, ok := w.w.(*ByteBuffer)
+	if ok {
+		bb.B = strconv.AppendInt(bb.B, int64(n), 10)
+	} else {
+		w.b = strconv.AppendInt(w.b[:0], int64(n), 10)
+		w.Write(w.b)
+	}
+}
+
 // DUL writes n to w
 func (w *QWriter) DUL(n uint64) {
 	bb, ok := w.w.(*ByteBuffer)
@@ -132,6 +165,39 @@ func (w *QWriter) DUL(n uint64) {
 		bb.B = strconv.AppendUint(bb.B, n, 10)
 	} else {
 		w.b = strconv.AppendUint(w.b[:0], n, 10)
+		w.Write(w.b)
+	}
+}
+
+// DUL32 writes n to w
+func (w *QWriter) DUL32(n uint32) {
+	bb, ok := w.w.(*ByteBuffer)
+	if ok {
+		bb.B = strconv.AppendUint(bb.B, uint64(n), 10)
+	} else {
+		w.b = strconv.AppendUint(w.b[:0], uint64(n), 10)
+		w.Write(w.b)
+	}
+}
+
+// DUL16 writes n to w
+func (w *QWriter) DUL16(n uint16) {
+	bb, ok := w.w.(*ByteBuffer)
+	if ok {
+		bb.B = strconv.AppendUint(bb.B, uint64(n), 10)
+	} else {
+		w.b = strconv.AppendUint(w.b[:0], uint64(n), 10)
+		w.Write(w.b)
+	}
+}
+
+// DUL8 writes n to w
+func (w *QWriter) DUL8(n uint8) {
+	bb, ok := w.w.(*ByteBuffer)
+	if ok {
+		bb.B = strconv.AppendUint(bb.B, uint64(n), 10)
+	} else {
+		w.b = strconv.AppendUint(w.b[:0], uint64(n), 10)
 		w.Write(w.b)
 	}
 }
@@ -170,8 +236,6 @@ func (w *QWriter) Q(s string) {
 		w.Write(w.b)
 	}
 }
-
-var strQuote = []byte(`"`)
 
 // QZ writes quoted json-safe z to w.
 func (w *QWriter) QZ(z []byte) {

--- a/writer_test.go
+++ b/writer_test.go
@@ -21,7 +21,8 @@ func TestWriter(t *testing.T) {
 
 	wn.S("<a></a>")
 	wn.D(123)
-	we.DUL(18446744073709551615)
+	wn.DUL(18446744073709551615)
+	wn.DUL32(4294967295)
 	wn.Z([]byte("'"))
 	wn.Q("foo")
 	wn.J("ds")
@@ -36,6 +37,7 @@ func TestWriter(t *testing.T) {
 	we.S("<a></a>")
 	we.D(321)
 	we.DUL(18446744073709551615)
+	we.DUL32(4294967295)
 	we.Z([]byte("'"))
 	we.Q("foo")
 	we.J("ds")
@@ -49,8 +51,8 @@ func TestWriter(t *testing.T) {
 
 	ReleaseWriter(qw)
 
-	expectedS := "<a></a>12318446744073709551615'\"foo\"ds1.23%D0%B0%D0%B1%D0%B2{}aaa\"asadf\"asdabc" +
-		"&lt;a&gt;&lt;/a&gt;32118446744073709551615&#39;&quot;foo&quot;ds1.23%D0%B0%D0%B1%D0%B2{}aaa&quot;asadf&quot;asdabc"
+	expectedS := "<a></a>123184467440737095516154294967295'\"foo\"ds1.23%D0%B0%D0%B1%D0%B2{}aaa\"asadf\"asdabc" +
+		"&lt;a&gt;&lt;/a&gt;321184467440737095516154294967295&#39;&quot;foo&quot;ds1.23%D0%B0%D0%B1%D0%B2{}aaa&quot;asadf&quot;asdabc"
 	if string(bb.B) != expectedS {
 		t.Fatalf("unexpected output:\n%q\nExpecting\n%q", bb.B, expectedS)
 	}


### PR DESCRIPTION
1. Add all standard int type for compiler read.

2. Delete an unused variable "strQuote" in writer.go

3. use strings.TrimSuffix() instead of strings.HasSuffix() for less if else statement.