### PR TITLE
Reduce Memory Usage by Optimizing Order of Fields

### DIFF
--- a/jsonstring.go
+++ b/jsonstring.go
@@ -59,8 +59,8 @@ var jsonReplacer = newByteReplacer(func() ([]byte, []string) {
 }())
 
 type byteReplacer struct {
-	m   [256]byte
 	newStrings []string
+	m          [256]byte
 }
 
 func newByteReplacer(oldChars []byte, newStrings []string) *byteReplacer {
@@ -79,7 +79,7 @@ func newByteReplacer(oldChars []byte, newStrings []string) *byteReplacer {
 		m[c] = byte(i)
 	}
 	return &byteReplacer{
-		m:   m,
+		m:          m,
 		newStrings: newStrings,
 	}
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -13,14 +13,15 @@ import (
 )
 
 type parser struct {
-	s                *scanner
-	w                io.Writer
-	packageName      string
+	w               io.Writer
+	s               *scanner
+	packageName     string
+	prefix          string
+	forDepth        int
+	switchDepth     int
+	skipOutputDepth int
+
 	skipLineComments bool
-	prefix           string
-	forDepth         int
-	switchDepth      int
-	skipOutputDepth  int
 
 	importsUseEmitted  bool
 	packageNameEmitted bool

--- a/parser/scanner.go
+++ b/parser/scanner.go
@@ -31,8 +31,9 @@ func tokenIDToStr(id int) string {
 }
 
 type token struct {
-	ID    int
 	Value []byte
+
+	ID int
 
 	line int
 	pos  int
@@ -51,25 +52,29 @@ func (t *token) String() string {
 }
 
 type scanner struct {
-	r   *bufio.Reader
-	t   token
-	c   byte
 	err error
+
+	r *bufio.Reader
 
 	filePath string
 
-	line    int
 	lineStr []byte
+
+	capturedValue []byte
+
+	t token
+
+	line int
 
 	nextTokenID int
 
-	capture       bool
-	capturedValue []byte
-
 	collapseSpaceDepth int
 	stripSpaceDepth    int
-	stripToNewLine     bool
-	rewind             bool
+	c                  byte
+
+	capture        bool
+	stripToNewLine bool
+	rewind         bool
 }
 
 var tailOfLine = regexp.MustCompile(`^[[:blank:]]*(?:\r*\n)?`)

--- a/parser/scanner_test.go
+++ b/parser/scanner_test.go
@@ -323,6 +323,6 @@ func testScannerSuccess(t *testing.T, str string, expectedTokens []tt) {
 }
 
 type tt struct {
-	ID    int
 	Value string
+	ID    int
 }


### PR DESCRIPTION
Optimized the order of fields in several structs, this results in a reduction of memory usage by `quicktemplate`.

Summary:

```console
/quicktemplate/jsonstring.go:61:19: 256 bytes saved: struct with 264 pointer bytes could be 8
/quicktemplate/parser/parser.go:15:13: 8 bytes saved: struct of size 96 could be 88
/quicktemplate/parser/scanner.go:33:12: 8 bytes saved: struct with 16 pointer bytes could be 8
/quicktemplate/parser/scanner.go:53:14: 16 bytes saved: struct of size 192 could be 176
/quicktemplate/parser/scanner_test.go:325:9: 8 bytes saved: struct with 16 pointer bytes could be 8
```