### PR TITLE
Add implements io.StringWriter to bytebuffer.go, need for jsonReplacer

### DIFF
--- a/bytebuffer.go
+++ b/bytebuffer.go
@@ -17,6 +17,11 @@ func (b *ByteBuffer) Write(p []byte) (int, error) {
 	return bb(b).Write(p)
 }
 
+// WriteString implements io.StringWriter.
+func (b *ByteBuffer) WriteString(s string) (n int, err error) {
+	return bb(b).WriteString(s)
+}
+
 // Reset resets the byte buffer.
 func (b *ByteBuffer) Reset() {
 	bb(b).Reset()


### PR DESCRIPTION
A new stringWriter is created in the strings package in replace.go:550 if the buffer does not implement the io.StringWriter interface. To prevent this from happening, an io.StringWriter implementation for the ByteBuffer is added 